### PR TITLE
ISSUE#2 - Ability to store approval files under different folder

### DIFF
--- a/java/com/spun/util/AnnotationUtils.java
+++ b/java/com/spun/util/AnnotationUtils.java
@@ -1,0 +1,42 @@
+package com.spun.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+public class AnnotationUtils
+{
+  /**
+   * Returns first occurrence of specified annotation if one is
+   * found on method or class within current thread stack trace.
+   * @param annotationClass to search for
+   * @return found annotationClass or null if not found
+   */
+  public static <T extends Annotation> T getAnnotationFromStackTrace(Class<T> annotationClass)
+  {
+    StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+    for (StackTraceElement stack : trace)
+    {
+      Method method = null;
+      Class<?> clazz = null;
+      try
+      {
+        String methodName = stack.getMethodName();
+        clazz = Class.forName(stack.getClassName());
+        method = clazz.getMethod(methodName, null);
+      }
+      catch (Exception e)
+      {
+        //ignore
+      }
+      T annotation = null;
+      if (method != null)
+      {
+        annotation = method.getAnnotation(annotationClass);
+      }
+      if (annotation != null) { return annotation; }
+      annotation = clazz.getAnnotation(annotationClass);
+      if (annotation != null) { return annotation; }
+    }
+    return null;
+  }
+}

--- a/java/org/approvaltests/Approvals.java
+++ b/java/org/approvaltests/Approvals.java
@@ -19,6 +19,7 @@ import org.approvaltests.core.ApprovalFailureOverrider;
 import org.approvaltests.core.ApprovalFailureReporter;
 import org.approvaltests.core.ApprovalWriter;
 import org.approvaltests.namer.ApprovalNamer;
+import org.approvaltests.namer.ApprovalNamerFactory;
 import org.approvaltests.namer.JUnitStackTraceNamer;
 import org.approvaltests.reporters.ExecutableQueryFailure;
 import org.approvaltests.writers.ApprovalBinaryFileWriter;
@@ -334,7 +335,7 @@ public class Approvals
   }
   public static ApprovalNamer createApprovalNamer()
   {
-    return new JUnitStackTraceNamer();
+    return ApprovalNamerFactory.getApprovalNamer();
   }
   private static void approve(BufferedImage bufferedImage, ApprovalNamer namer)
   {
@@ -355,7 +356,7 @@ public class Approvals
   private static void verifyEachFileAgainstMasterDirectory(File[] files) throws Error
   {
     ApprovalNamer namer = createApprovalNamer();
-    String dirName = namer.getSourceFilePath() + Path.SEPARATOR + namer.getApprovalName() + ".Files";
+    String dirName = namer.getApprovalFileBasePath() + Path.SEPARATOR + namer.getApprovalName() + ".Files";
     File approvedDirectory = new File(dirName);
     List<File> mismatched = new ArrayList<File>();
     for (File f : files)

--- a/java/org/approvaltests/ReporterFactory.java
+++ b/java/org/approvaltests/ReporterFactory.java
@@ -1,7 +1,5 @@
 package org.approvaltests;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +12,7 @@ import org.approvaltests.reporters.MultiReporter;
 import org.approvaltests.reporters.QuietReporter;
 import org.approvaltests.reporters.UseReporter;
 
+import com.spun.util.AnnotationUtils;
 import com.spun.util.ClassUtils;
 
 public class ReporterFactory
@@ -41,7 +40,7 @@ public class ReporterFactory
   }
   public static ApprovalFailureReporter getFromAnnotation()
   {
-    UseReporter reporter = getAnnotationFromStackTrace(UseReporter.class);
+    UseReporter reporter = AnnotationUtils.getAnnotationFromStackTrace(UseReporter.class);
     return reporter == null ? null : getReporter(reporter);
   }
   private static ApprovalFailureReporter getReporter(UseReporter reporter)
@@ -54,34 +53,6 @@ public class ReporterFactory
       reporters.add(instance);
     }
     return reporters.size() == 1 ? reporters.get(0) : new MultiReporter(reporters);
-  }
-  private static <T extends Annotation> T getAnnotationFromStackTrace(Class<T> annotationClass)
-  {
-    StackTraceElement[] trace = Thread.currentThread().getStackTrace();
-    for (StackTraceElement stack : trace)
-    {
-      Method method = null;
-      Class<?> clazz = null;
-      try
-      {
-        String methodName = stack.getMethodName();
-        clazz = Class.forName(stack.getClassName());
-        method = clazz.getMethod(methodName, null);
-      }
-      catch (Exception e)
-      {
-        //ignore
-      }
-      T annotation = null;
-      if (method != null)
-      {
-        annotation = method.getAnnotation(annotationClass);
-      }
-      if (annotation != null) { return annotation; }
-      annotation = clazz.getAnnotation(annotationClass);
-      if (annotation != null) { return annotation; }
-    }
-    return null;
   }
   private static ApprovalFailureReporter tryFor(ApprovalFailureReporter returned,
       Class<? extends ApprovalFailureReporter> trying)

--- a/java/org/approvaltests/approvers/FileApprover.java
+++ b/java/org/approvaltests/approvers/FileApprover.java
@@ -23,7 +23,7 @@ public class FileApprover implements ApprovalApprover
   public FileApprover(ApprovalWriter writter, ApprovalNamer namer)
   {
     this.writter = writter;
-    String base = String.format("%s%s%s", namer.getSourceFilePath(), namer.getApprovalName(),
+    String base = String.format("%s%s%s", namer.getApprovalFileBasePath(), namer.getApprovalName(),
         NamerFactory.getAndClearAdditionalInformation());
     received = new File(writter.getReceivedFilename(base));
     approved = new File(writter.getApprovalFilename(base));

--- a/java/org/approvaltests/namer/ApprovalNamer.java
+++ b/java/org/approvaltests/namer/ApprovalNamer.java
@@ -2,6 +2,15 @@ package org.approvaltests.namer;
 
 public interface ApprovalNamer
 {
+  /**
+   * Returns approval name.
+   * @return approval name.
+   */
   String getApprovalName();
-  String getSourceFilePath();
+  
+  /**
+   * Returns base path where approval file is to be created.
+   * @return base path where approval file is to be created.
+   */
+  String getApprovalFileBasePath();
 }

--- a/java/org/approvaltests/namer/ApprovalNamerFactory.java
+++ b/java/org/approvaltests/namer/ApprovalNamerFactory.java
@@ -1,0 +1,20 @@
+package org.approvaltests.namer;
+
+import com.spun.util.AnnotationUtils;
+import com.spun.util.ClassUtils;
+
+public class ApprovalNamerFactory
+{
+  /**
+   * Returns instance of {@link ApprovalNamer} specified in {@link ApprovalsNamer} annotation.<br>
+   * If {@link ApprovalsNamer} annotation is not used, {@link JUnitStackTraceNamer} instance is returned.
+   * 
+   * @return {@link ApprovalNamer} instance
+   */
+  public static ApprovalNamer getApprovalNamer()
+  {
+    ApprovalsNamer approvalsNamer = AnnotationUtils.getAnnotationFromStackTrace(ApprovalsNamer.class);
+    if (approvalsNamer == null || approvalsNamer.value() == null) { return new JUnitStackTraceNamer(); }
+    return ClassUtils.create(approvalsNamer.value());
+  }
+}

--- a/java/org/approvaltests/namer/ApprovalsNamer.java
+++ b/java/org/approvaltests/namer/ApprovalsNamer.java
@@ -1,0 +1,16 @@
+package org.approvaltests.namer;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Use this annotation on class or method level to specify custom 
+ * {@link ApprovalNamer} to be used.
+ * 
+ * @author mzagar
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApprovalsNamer {
+  Class<? extends ApprovalNamer> value() default JUnitStackTraceNamer.class;
+}

--- a/java/org/approvaltests/namer/JUnitStackTraceNamer.java
+++ b/java/org/approvaltests/namer/JUnitStackTraceNamer.java
@@ -25,7 +25,7 @@ public class JUnitStackTraceNamer implements ApprovalNamer
     return String.format("%s.%s", info.getClassName(), info.getMethodName());
   }
   @Override
-  public String getSourceFilePath()
+  public String getApprovalFileBasePath()
   {
     return info.getSourceFile().getAbsolutePath() + File.separator;
   }
@@ -59,7 +59,8 @@ public class JUnitStackTraceNamer implements ApprovalNamer
       }
       return junit3;
     }
-    private boolean isTestAttribute(Class<?> clazz, String methodName) throws ClassNotFoundException, SecurityException
+    private boolean isTestAttribute(Class<?> clazz, String methodName) throws ClassNotFoundException,
+        SecurityException
     {
       Method method;
       try
@@ -69,8 +70,7 @@ public class JUnitStackTraceNamer implements ApprovalNamer
       catch (Throwable e)
       {
         return false;
-      } 
-      
+      }
       return method.isAnnotationPresent(Test.class);
     }
   }

--- a/java/org/approvaltests/namer/MavenResourcesApprovalNamer.java
+++ b/java/org/approvaltests/namer/MavenResourcesApprovalNamer.java
@@ -1,0 +1,40 @@
+package org.approvaltests.namer;
+
+import java.io.File;
+
+import org.approvaltests.namer.JUnitStackTraceNamer;
+
+/**
+ * Uses maven test resources folder as base approval file folder.
+ *
+ * @author mzagar
+ *
+ */
+public final class MavenResourcesApprovalNamer implements ApprovalNamer
+{
+  private static final String        mavenSourceBase = "src/test/java".replace("/", File.separator);
+  private static final String        mavenTestBase   = "src/test/resources".replace("/", File.separator);
+  private final JUnitStackTraceNamer namer;
+  
+  public MavenResourcesApprovalNamer()
+  {
+    this(new JUnitStackTraceNamer());
+  }
+  
+  public MavenResourcesApprovalNamer(JUnitStackTraceNamer junitStackTraceNamer)
+  {
+    this.namer = junitStackTraceNamer;
+  }
+  
+  @Override
+  public String getApprovalFileBasePath()
+  {
+    return namer.getApprovalFileBasePath().replace(mavenSourceBase, mavenTestBase);
+  }
+  
+  @Override
+  public String getApprovalName()
+  {
+    return namer.getApprovalName();
+  }
+}

--- a/java/org/approvaltests/namer/tests/ApprovalNamerFactoryTest.java
+++ b/java/org/approvaltests/namer/tests/ApprovalNamerFactoryTest.java
@@ -1,0 +1,54 @@
+package org.approvaltests.namer.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.approvaltests.namer.ApprovalNamer;
+import org.approvaltests.namer.ApprovalNamerFactory;
+import org.approvaltests.namer.ApprovalsNamer;
+import org.approvaltests.namer.JUnitStackTraceNamer;
+import org.approvaltests.namer.MavenResourcesApprovalNamer;
+import org.junit.Test;
+
+public class ApprovalNamerFactoryTest {
+
+	@Test
+	public void returns_JUnitStackTraceNamer_if_ApprovalsNamer_annotation_is_not_specified() {
+		assertEquals(JUnitStackTraceNamer.class, new WithoutApprovalsNamerAnnotation().test().getClass());
+	}
+
+	@Test
+	public void returns_ApprovalsNamer_instance_for_class_level_ApprovalsNamer_annotation() {
+		assertEquals(MavenResourcesApprovalNamer.class, new WithApprovalsNamerClassLevelAnnotation().test().getClass());
+	}
+	
+	@Test
+	public void returns_ApprovalsNamer_instance_for_method_level_ApprovalsNamer_annotation() {
+		assertEquals(JUnitStackTraceNamer.class, new WithApprovalsNamerMethodLevelAnnotation().test1().getClass());
+		assertEquals(MavenResourcesApprovalNamer.class, new WithApprovalsNamerMethodLevelAnnotation().test2().getClass());
+	}
+
+	private static class WithoutApprovalsNamerAnnotation {
+		public ApprovalNamer test() {
+			return ApprovalNamerFactory.getApprovalNamer();
+		}
+	}
+
+	@ApprovalsNamer(MavenResourcesApprovalNamer.class)
+	private static class WithApprovalsNamerClassLevelAnnotation {
+		public ApprovalNamer test() {
+			return ApprovalNamerFactory.getApprovalNamer();
+		}
+	}
+
+	@ApprovalsNamer(MavenResourcesApprovalNamer.class)
+	private static class WithApprovalsNamerMethodLevelAnnotation {
+		@ApprovalsNamer(JUnitStackTraceNamer.class)
+		public ApprovalNamer test1() {
+			return ApprovalNamerFactory.getApprovalNamer();
+		}
+
+		public ApprovalNamer test2() {
+			return ApprovalNamerFactory.getApprovalNamer();
+		}
+	}
+}

--- a/java/org/approvaltests/namer/tests/JUnit4StackTraceNamerTest.java
+++ b/java/org/approvaltests/namer/tests/JUnit4StackTraceNamerTest.java
@@ -18,7 +18,7 @@ public class JUnit4StackTraceNamerTest
   public void testGetSourceFilePath() throws Exception
   {
     JUnitStackTraceNamer name = new JUnitStackTraceNamer();
-    File file = new File(name.getSourceFilePath() + "JUnitStackTraceNamerTest.java");
+    File file = new File(name.getApprovalFileBasePath() + "JUnitStackTraceNamerTest.java");
     Assert.assertTrue(file.exists());
   }
 }

--- a/java/org/approvaltests/namer/tests/JUnitStackTraceNamerTest.java
+++ b/java/org/approvaltests/namer/tests/JUnitStackTraceNamerTest.java
@@ -13,10 +13,10 @@ public class JUnitStackTraceNamerTest extends TestCase
     JUnitStackTraceNamer name = new JUnitStackTraceNamer();
     assertEquals("JUnitStackTraceNamerTest.testGetApprovalName", name.getApprovalName());
   }
-  public void testGetSourceFilePath() throws Exception
+  public void testGetApprovalBasePath() throws Exception
   {
     JUnitStackTraceNamer name = new JUnitStackTraceNamer();
-    File file = new File(name.getSourceFilePath() + "JUnitStackTraceNamerTest.java");
+    File file = new File(name.getApprovalFileBasePath() + "JUnitStackTraceNamerTest.java");
     assertTrue(file.exists());
   }
   public void testEmbeddedStackName()

--- a/java/org/approvaltests/namer/tests/MavenResourcesApprovalNamerTest.java
+++ b/java/org/approvaltests/namer/tests/MavenResourcesApprovalNamerTest.java
@@ -1,0 +1,17 @@
+package org.approvaltests.namer.tests;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.approvaltests.namer.JUnitStackTraceNamer;
+import org.approvaltests.namer.MavenResourcesApprovalNamer;
+import org.junit.Test;
+
+public class MavenResourcesApprovalNamerTest {
+	@Test
+	public void testGetApprovalsBasePath() {
+		JUnitStackTraceNamer namer = mock(JUnitStackTraceNamer.class);
+		when(namer.getApprovalFileBasePath()).thenReturn("C:\\maven_project\\src\\test\\java\\some\\packet\\");
+		assertEquals("C:\\maven_project\\src\\test\\resources\\some\\packet\\", new MavenResourcesApprovalNamer(namer).getApprovalFileBasePath());
+	}
+}


### PR DESCRIPTION
Hi, please review my proposed changes for extending Approvals to enable storing approval files under different folder.

I introduced @ApprovalsNamer annotation to support custom ApprovalNamer implementations.

Also added convenient MavenResourcesApprovalNamer custom implementation which stores approval files under default maven src/test/resources folder.

Your feedback is greatly appreciated.
