### PR TITLE
Fix null-pointer exception in multi classloader enviromnment

### DIFF
--- a/java/org/approvaltests/ReporterFactory.java
+++ b/java/org/approvaltests/ReporterFactory.java
@@ -78,7 +78,7 @@ public class ReporterFactory
         annotation = method.getAnnotation(annotationClass);
       }
       if (annotation != null) { return annotation; }
-      annotation = clazz.getAnnotation(annotationClass);
+      annotation = clazz!=null ? clazz.getAnnotation(annotationClass) : null;
       if (annotation != null) { return annotation; }
     }
     return null;


### PR DESCRIPTION
- When we cannot find the class of the stack trace (for example in SBT the classes are loaded in different loaders), it will have null as class. Check for that null
