### PR TITLE
Added pom.xmls for existing codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -50,24 +50,28 @@ ApprovalTests eats it own dogfood, so the best examples are in the source code i
 None the less,  Here's a quick look at some
 [Sample Code](https://github.com/approvals/ApprovalTests.Java/blob/master/java/org/approvaltests/tests/demos/SampleArrayTest.java)
 
-	public class SampleArrayTest extends TestCase
+```java
+public class SampleArrayTest extends TestCase
+{
+	public void testList() throws Exception
 	{
-		public void testList() throws Exception
-		{
-			String[] names = {"Llewellyn", "James", "Dan", "Jason", "Katrina"};
-			Arrays.sort(names);
-			Approvals.verifyAll("", names);
-		}
+		String[] names = {"Llewellyn", "James", "Dan", "Jason", "Katrina"};
+		Arrays.sort(names);
+		Approvals.verifyAll("", names);
 	}
+}
+```
 
 Will Produce a File
 
-    SampleTest.TestList.received.txt
-    [0] = Dan
-    [1] = James
-    [2] = Jason
-    [3] = Katrina
-    [4] = Llewellyn
+```
+SampleTest.TestList.received.txt
+[0] = Dan
+[1] = James
+[2] = Jason
+[3] = Katrina
+[4] = Llewellyn
+```
 
 Simply rename this to SampleTest.testList.approved.txt and the test will now pass.
 
@@ -98,16 +102,23 @@ twitter: [@LlewellynFalco](https://twitter.com/#!/llewellynfalco) or #ApprovalTe
 Developer notes
 ----------------
 
+### Building with Ant
+
 If you would like to build this project locally, install Apache ant,
 then use these commands:
 
-     ant "Publish    Spun" -buildfile build/build.xml
-     cp spun/target/spun.jar java/jars/
-     ant "Publish    ApprovalTests" -buildfile build/build.xml
-     cp approvals/target/ApprovalTests.jar java/jars
-     ant "Publish    HtmlLocker" -buildfile build/build.xml
-     ant "Publish    CounterDisplay" -buildfile build/build.xml
+```shell
+ant "Publish    Spun" -buildfile build/build.xml
+cp spun/target/spun.jar java/jars/
+ant "Publish    ApprovalTests" -buildfile build/build.xml
+cp approvals/target/ApprovalTests.jar java/jars
+ant "Publish    HtmlLocker" -buildfile build/build.xml
+ant "Publish    CounterDisplay" -buildfile build/build.xml
+```
 
 This will build jar files under the target folder for each respective project. At present you have to 
-copy the built jar files by hand in between ant steps, since the subprojects depned on one another.
-Soon this will be handled by maven instead.
+copy the built jar files by hand in between ant steps, since the subprojects depend on one another.
+
+### Building with Maven
+
+Run `mvn clean package` to get jar files

--- a/approvals/pom.xml
+++ b/approvals/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<parent>
+		<relativePath>../pom.xml</relativePath>
+		<groupId>com.approvaltests</groupId>
+		<artifactId>approvaltests</artifactId>
+		<version>0.2-SNAPSHOT</version>
+	</parent>
+
+	<groupId>com.approvaltests</groupId>
+	<artifactId>approvals</artifactId>
+	<version>0.2-SNAPSHOT</version>
+	
+	<properties>
+		<maven.test.skip>true</maven.test.skip>
+	</properties>
+	
+	<dependencies>
+		<dependency>
+			<groupId>com.approvaltests</groupId>
+			<artifactId>spun</artifactId>
+			<version>0.2-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8.2</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.hadoop</groupId>
+		    <artifactId>hadoop-core</artifactId>
+		    <version>0.20.2</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.mrunit</groupId>
+		    <artifactId>mrunit</artifactId>
+		    <version>0.9.0-incubating</version>
+		    <classifier>hadoop2</classifier> 
+		    <scope>provided</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.testng</groupId>
+		    <artifactId>testng</artifactId>
+		    <version>6.9.10</version>
+		    <scope>provided</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.easymock</groupId>
+		    <artifactId>easymock</artifactId>
+		    <version>2.3</version>
+		    <scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/counter_display/pom.xml
+++ b/counter_display/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<parent>
+		<relativePath>../pom.xml</relativePath>
+		<groupId>com.approvaltests</groupId>
+		<artifactId>approvaltests</artifactId>
+		<version>0.2-SNAPSHOT</version>
+	</parent>
+
+	<groupId>com.approvaltests</groupId>
+	<artifactId>counter_display</artifactId>
+	<version>0.2-SNAPSHOT</version>
+	
+	<dependencies>
+		<dependency>
+			<groupId>com.approvaltests</groupId>
+			<artifactId>approvals</artifactId>
+			<version>0.2-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+	
+</project>

--- a/html_locker/pom.xml
+++ b/html_locker/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<parent>
+		<relativePath>../pom.xml</relativePath>
+		<groupId>com.approvaltests</groupId>
+		<artifactId>approvaltests</artifactId>
+		<version>0.2-SNAPSHOT</version>
+	</parent>
+
+	<groupId>com.approvaltests</groupId>
+	<artifactId>html_locker</artifactId>
+	<version>0.2-SNAPSHOT</version>
+	
+	<dependencies>
+		<dependency>
+			<groupId>com.approvaltests</groupId>
+			<artifactId>approvals</artifactId>
+			<version>0.2-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+	
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<groupId>com.approvaltests</groupId>
+	<artifactId>approvaltests</artifactId>
+	<version>0.2-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<description>ApprovalTest verification library for Java</description>
+	<name>ApprovalTest.Java</name>
+	<url>http://approvaltests.com/</url>
+
+	<scm>
+		<url>${scm.url}</url>
+		<connection>scm:git:${scm.url}</connection>
+	</scm>
+
+	<properties>
+		<scm.url>ssh://git@github.com:approvals/ApprovalTests.Java.git</scm.url>
+		<sourceJavaVersion>1.8</sourceJavaVersion>
+		<targetJavaVersion>1.8</targetJavaVersion>
+	</properties>
+
+	<modules>
+		<module>spun</module>
+		<module>approvals</module>
+		<module>html_locker</module>
+		<module>counter_display</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
+				<configuration>
+					<source>${sourceJavaVersion}</source>
+					<target>${targetJavaVersion}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.7</version>
+				<extensions>true</extensions>
+				<configuration>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+				</configuration>
+			</plugin>
+			<!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-gpg-plugin</artifactId> 
+				<version>1.5</version> <executions> <execution> <id>sign-artifacts</id> <phase>verify</phase> 
+				<goals> <goal>sign</goal> </goals> </execution> </executions> </plugin> -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+					<autoVersionSubmodules>true</autoVersionSubmodules>
+					<useReleaseProfile>false</useReleaseProfile>
+					<releaseProfiles>release</releaseProfiles>
+					<goals>deploy</goals>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+	</distributionManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,15 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<additionalparam>-Xdoclint:none</additionalparam>
+					<additionalOptions>-Xdoclint:none</additionalOptions>
+					<additionalJOption>-Xdoclint:none</additionalJOption>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
 				<version>1.6.7</version>
@@ -60,9 +69,20 @@
 					<autoReleaseAfterClose>true</autoReleaseAfterClose>
 				</configuration>
 			</plugin>
-			<!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-gpg-plugin</artifactId> 
-				<version>1.5</version> <executions> <execution> <id>sign-artifacts</id> <phase>verify</phase> 
-				<goals> <goal>sign</goal> </goals> </execution> </executions> </plugin> -->
+			<!-- <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.5</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin> -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>

--- a/spun/pom.xml
+++ b/spun/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<parent>
+		<relativePath>../pom.xml</relativePath>
+		<groupId>com.approvaltests</groupId>
+		<artifactId>approvaltests</artifactId>
+		<version>0.2-SNAPSHOT</version>
+	</parent>
+
+	<groupId>com.approvaltests</groupId>
+	<artifactId>spun</artifactId>
+	<version>0.2-SNAPSHOT</version>
+	
+	<properties>
+		<maven.test.skip>true</maven.test.skip>
+	</properties>
+	
+	<dependencies>
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>1.0.3</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-httpclient</groupId>
+			<artifactId>commons-httpclient</artifactId>
+			<version>2.0-rc3</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<version>2.3</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>velocity</groupId>
+			<artifactId>velocity</artifactId>
+			<version>1.4</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.7</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>sshtools</groupId>
+			<artifactId>j2ssh-core</artifactId>
+			<version>0.2.9</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.9</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.mail</groupId>
+			<artifactId>javax.mail-api</artifactId>
+			<version>1.4.4</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8.2</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>quartz</groupId>
+			<artifactId>quartz</artifactId>
+			<version>1.4.5</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-net</groupId>
+			<artifactId>commons-net</artifactId>
+			<version>1.1.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>acme</groupId>
+			<artifactId>acme</artifactId>
+			<version>1.0</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/../java/jars/acme.jar</systemPath>
+		</dependency>
+	</dependencies>
+
+</project>


### PR DESCRIPTION
Hi!

I would like to add POMs to build the project with maven. I noticed #38 but looks like it is a huge refactoring and it will take some time. But as I would like to use the library soon in one of the projects I would like to have something before work on #38 will be done.
All the dependencies are marked as `provided`.
Looks like namespace `com.approvaltests` is not registered in OSS Repository Hosting but still I added plugins configured to publish artifacts there. So once you go through https://central.sonatype.org/pages/ossrh-guide.html it should be possible to publish artifacts with `mvn release:clean release:prepare release:perform`. 
There is also `.travis.yml` so if you register on https://travis-ci.org/ you can get your project build and publish artifacts automatically.

Matt