### PR TITLE
Added IntelliJ Community and Intellij Ultimate diff tool reporter for Windows

### DIFF
--- a/approvaltests-util/pom.xml
+++ b/approvaltests-util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>approvaltests-parent</artifactId>
         <groupId>com.approvaltests</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>approvaltests-util</artifactId>

--- a/approvaltests/pom.xml
+++ b/approvaltests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>approvaltests-parent</artifactId>
         <groupId>com.approvaltests</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
 
     <artifactId>approvaltests</artifactId>

--- a/approvaltests/src/main/doc/ApprovalTests - GettingStarted.md
+++ b/approvaltests/src/main/doc/ApprovalTests - GettingStarted.md
@@ -224,6 +224,8 @@ WinMerge            | WIN_MERGE_REPORTER
 Araxis Merge        | ARAXIS_MERGE
 Code Compare        | CODE_COMPARE
 KDiff3              | KDIFF3
+IntelliJ Ultimate   |INTELLIJ_U
+IntelliJ Community  |INTELLI_C
 
 To use a reporter that is not in the above list, you will need to create a class of the following form:
 

--- a/approvaltests/src/main/java/org/approvaltests/reporters/macosx/DiffPrograms.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/macosx/DiffPrograms.java
@@ -1,11 +1,14 @@
 package org.approvaltests.reporters.macosx;
 
-import java.util.List;
-
+import com.spun.util.ArrayUtils;
 import org.approvaltests.reporters.DiffInfo;
 import org.approvaltests.reporters.GenericDiffReporter;
+import org.approvaltests.reporters.windows.IntelliJCommunityReporter.IntelliJPathResolver;
 
-import com.spun.util.ArrayUtils;
+import java.util.List;
+
+import static org.approvaltests.reporters.windows.IntelliJCommunityReporter.IntelliJPathResolver.Edition.Community;
+import static org.approvaltests.reporters.windows.IntelliJCommunityReporter.IntelliJPathResolver.Edition.Ultimate;
 
 public class DiffPrograms
 {
@@ -45,6 +48,8 @@ public class DiffPrograms
     public static DiffInfo CODE_COMPARE        = new DiffInfo(
         "{ProgramFiles}Devart\\Code Compare\\CodeCompare.exe", TEXT);
     public static DiffInfo KDIFF3              = new DiffInfo("{ProgramFiles}KDiff3\\kdiff3.exe", TEXT);
+    public static DiffInfo INTELLIJ_C = new DiffInfo(new IntelliJPathResolver(Community).findIt(), "diff %s %s", TEXT);
+    public static DiffInfo INTELLIJ_U = new DiffInfo(new IntelliJPathResolver(Ultimate).findIt(), "diff %s %s", TEXT);
     public static DiffInfo VISUAL_STUDIO_CODE  = new DiffInfo("{ProgramFiles}Microsoft VS Code\\Code.exe",
         "-d %s %s", TEXT);
   }

--- a/approvaltests/src/main/java/org/approvaltests/reporters/windows/IntelliJCommunityReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/windows/IntelliJCommunityReporter.java
@@ -1,0 +1,102 @@
+package org.approvaltests.reporters.windows;
+
+import org.approvaltests.reporters.GenericDiffReporter;
+import org.approvaltests.reporters.macosx.DiffPrograms.Windows;
+
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.Integer.parseInt;
+
+public class IntelliJCommunityReporter extends GenericDiffReporter {
+    public static final IntelliJCommunityReporter INSTANCE = new IntelliJCommunityReporter();
+
+    private IntelliJCommunityReporter() {
+        super(Windows.INTELLIJ_C);
+    }
+
+    public static class IntelliJPathResolver {
+
+        private final String appData = System.getenv("LOCALAPPDATA");
+        private final String toolboxPath = appData + "/JetBrains/Toolbox";
+        private final String runtimeSuffix = "/bin/idea64.exe";
+        private final String notPresentPath = "C:\\Intelli-not-present.exe";
+        private final String channelsPath;
+
+
+        public IntelliJPathResolver(Edition edition) {
+            this.channelsPath = toolboxPath + "/apps/" + edition.getDirectory() + "/ch-0/";
+        }
+
+        public String findIt() {
+            try {
+                return getIntellJPath().map(Objects::toString).orElse(notPresentPath);
+            } catch (IOException e) {
+                return notPresentPath;
+            }
+        }
+
+        private Optional<Path> getIntellJPath() throws IOException {
+            return Files.walk(Paths.get(channelsPath), 1, FileVisitOption.FOLLOW_LINKS)
+                    .map(Path::getFileName)
+                    .map(Objects::toString)
+                    .filter(Version::isVersionFile)
+                    .map(Version::new).min(Comparator.reverseOrder())
+                    .map(this::getPath);
+        }
+
+        private Path getPath(Version version) {
+            return Paths.get(channelsPath + version.version + runtimeSuffix).toAbsolutePath();
+        }
+
+        public enum Edition {
+            Community("IDEA-U"), Ultimate("IDEA-C");
+            private final String directory;
+
+            Edition(String directory) {
+                this.directory = directory;
+            }
+
+            public String getDirectory() {
+                return directory;
+            }
+        }
+    }
+
+    private static class Version implements Comparable<Version> {
+        final String version;
+
+        Version(java.lang.String version) {
+            this.version = version;
+        }
+
+        private static boolean isVersionFile(String version) {
+            return version.matches("[0-9]+(\\.[0-9]+)*");
+        }
+
+        @Override
+        public int compareTo(Version other) {
+            String[] thisParts = version.split("\\.");
+            String[] thatParts = other.version.split("\\.");
+            int length = Math.max(thisParts.length, thatParts.length);
+            for (int i = 0; i < length; i++) {
+                int thisPart = (i < thisParts.length) ? parseInt(thisParts[i]) : 0;
+                int thatPart = (i < thatParts.length) ? parseInt(thatParts[i]) : 0;
+                if (thisPart < thatPart) {
+                    return -1;
+                }
+                if (thisPart > thatPart) {
+                    return 1;
+                }
+            }
+            return 0;
+        }
+    }
+
+}

--- a/approvaltests/src/main/java/org/approvaltests/reporters/windows/IntelliJUltimateReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/windows/IntelliJUltimateReporter.java
@@ -1,0 +1,14 @@
+package org.approvaltests.reporters.windows;
+
+import org.approvaltests.reporters.GenericDiffReporter;
+import org.approvaltests.reporters.macosx.DiffPrograms.Windows;
+
+public class IntelliJUltimateReporter extends GenericDiffReporter {
+    public static final IntelliJUltimateReporter INSTANCE = new IntelliJUltimateReporter();
+
+    private IntelliJUltimateReporter() {
+        super(Windows.INTELLIJ_U);
+    }
+
+
+}

--- a/approvaltests/src/main/java/org/approvaltests/reporters/windows/WindowsDiffReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/windows/WindowsDiffReporter.java
@@ -9,6 +9,6 @@ public class WindowsDiffReporter extends FirstWorkingReporter
   {
     super(TortoiseDiffReporter.INSTANCE, BeyondCompareReporter.INSTANCE, VisualStudioCodeReporter.INSTANCE,
         WinMergeReporter.INSTANCE, AraxisMergeReporter.INSTANCE, CodeCompareReporter.INSTANCE,
-        KDiff3Reporter.INSTANCE);
+            KDiff3Reporter.INSTANCE, IntelliJUltimateReporter.INSTANCE, IntelliJCommunityReporter.INSTANCE);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.approvaltests</groupId>
     <artifactId>approvaltests-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>pom</packaging>
 
     <name>ApprovalTests.Java</name>


### PR DESCRIPTION
Added Windows support for the diff tool window integrated in [IntelliJ](https://www.jetbrains.com/idea/). Searches for the newest installed version and uses the x64 binaries.

**New Reporters:**

MS Windows          | Specified as
-----------         |---------
IntelliJ Ultimate   |INTELLIJ_U
IntelliJ Community  |INTELLI_C

Any feedback would be welcome. I don't have proper code formatter used in this project, so please apply a reformat code during merge.