### PR TITLE
f Make verify more extensible

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/Approvals.java
+++ b/approvaltests/src/main/java/org/approvaltests/Approvals.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.approvaltests.approvers.ApprovalApprover;
 import org.approvaltests.approvers.FileApprover;
 import org.approvaltests.core.ApprovalFailureReporter;
 import org.approvaltests.core.ApprovalWriter;
@@ -127,7 +128,7 @@ public class Approvals
   {
     verify(new ApprovalXmlWriter(xml));
   }
-  public static void verify(FileApprover approver, ApprovalFailureReporter reporter)
+  public static void verify(ApprovalApprover approver, ApprovalFailureReporter reporter)
   {
     try
     {


### PR DESCRIPTION
Change verify to use ApprovalApprover rather than FileApprover. This was a very easy,
and provably safe change, as the method in question did not depend on any FileApprover
specific methods. **We're just changing the parameter from the concrete FileApprover to the ApprovalApprover interface**. 

The concrete motivation for this change is to enable implementing
a threshold-based fuzzy image matching approver without duplicating the verify method.

## Description

This PR makes it easier to implement different kinds of approvers and leverage the same underlying Approvals.verify method. The motivating example is below (in Kotlin):

```
    fun verifyWithinTolerance(image: BufferedImage, tolerancePercentage: Int) {
       val approver : ApprovalApprover = TolerantImageApprover(
                image = image,
                tolerancePercentage = tolerancePercentage,
                namer = createApprovalNamer()
            )

        Approvals.verify(
            approver,
            getReporter()
        )
    }
```
Right now, it doesn't compile because "approver" is an ApprovalApprover, not a FileApprover.

Some additional background on the motivation for this change: I'm in the process of making a fuzzy image matcher approver. Specifically, I'm rendering some text to an image and it's practically impossible to get text to render images 100% consistently pixel by pixel across different machines (eg CI vs workstations).

## The solution

Change the signature of the method org.approvaltests.Approvals#verify(org.approvaltests.approvers.FileApprover, org.approvaltests.core.ApprovalFailureReporter) to org.approvaltests.Approvals#verify(org.approvaltests.approvers.ApprovalApprover, org.approvaltests.core.ApprovalFailureReporter) 

In the future, it would be good to also change FileApprover to take a comparison function to make the specific change that I want to make easier. However, this change is a good, safe, small, unobtrusive change.





