### PR TITLE
B fixed call to meld

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/reporters/DiffPrograms.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/DiffPrograms.java
@@ -61,6 +61,6 @@ public class DiffPrograms
   public static class Linux
   {
     public static DiffInfo DIFF_MERGE = new DiffInfo("/usr/bin/diffmerge", "--nosplash %s %s ", TEXT);
-    public static DiffInfo MELD_MERGE = new DiffInfo("/usr/bin/meld", "--nosplash %s %s ", TEXT);
+    public static DiffInfo MELD_MERGE = new DiffInfo("/usr/bin/meld", "%s %s ", TEXT);
   }
 }


### PR DESCRIPTION
The call to meld doesn't work on modern versions.  It will fail with: Error: no such option: --nosplash.  This will remove that option so it works.