### PR TITLE
Update IntelliJ runtime suffix for macOS.

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/reporters/intellij/IntelliJPathResolver.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/intellij/IntelliJPathResolver.java
@@ -28,7 +28,7 @@ public class IntelliJPathResolver
     {
       appData = System.getenv("HOME");
       appData += "/Library/Application Support";
-      runtimeSuffix = "/bin/idea";
+      runtimeSuffix = "/IntelliJ IDEA.app/Contents/MacOS/idea";
     }
     else // Linux
     {

--- a/approvaltests/src/test/java/machine_specific_tests/approvaltests/testcommitrevert/ArlosGitNotationPromptTest.java
+++ b/approvaltests/src/test/java/machine_specific_tests/approvaltests/testcommitrevert/ArlosGitNotationPromptTest.java
@@ -1,11 +1,12 @@
 package machine_specific_tests.approvaltests.testcommitrevert;
 
+import machine_specific_tests.MachineSpecificTest;
 import org.approvaltests.Approvals;
 import org.approvaltests.testcommitrevert.ArlosGitNotationPrompt;
 import org.junit.Test;
 
 //@UseReporter(ClipboardReporter.class)
-public class ArlosGitNotationPromptTest
+public class ArlosGitNotationPromptTest extends MachineSpecificTest
 {
   @Test
   public void test()


### PR DESCRIPTION
## Description

This PR updates the IntelliJ runtime suffix for macOS to reflect the current location placement done by Jetbrains Toolbox.

## The solution

This PR also updates Arlo's git commit prompt test to be machine specific, as the test was failing on my specific machine due to minor visual differences.