### PR TITLE
Fix jars download link to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ add this to your pom file:
 </dependency>
 ```
 
-or [download the jars from maven central repository](http://repo1.maven.org/maven2/com/approvaltests/approvaltests/)
+or [download the jars from maven central repository](https://repo1.maven.org/maven2/com/approvaltests/approvaltests/)
 
 [Video Tutorials](http://www.youtube.com/playlist?list=PLFBA98F47156EFAA9&feature=view_all)
 ---


### PR DESCRIPTION
Non SSL link throws error:

501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required