### PR TITLE
gh-actions: cache mvn dependencies + use junit 4.13 + remove dead link

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ If you prefer auditory learning, you might enjoy the following podcast (Note: So
 - [Cucumber Podcast](https://cucumber.io/blog/2017/01/26/approval-testing)
 - [Hanselminutes](https://www.hanselminutes.com/360/approval-tests-with-llewellyn-falco)
 - [Herding Code](https://www.developerfusion.com/media/122649/herding-code-117-llewellyn-falcon-on-approval-tests/)
-- [The Watir Podcast](https://watirpodcast.com/podcast-53/)
 
 
 

--- a/README.source.md
+++ b/README.source.md
@@ -62,7 +62,6 @@ If you prefer auditory learning, you might enjoy the following podcast (Note: So
 - [Cucumber Podcast](https://cucumber.io/blog/2017/01/26/approval-testing)
 - [Hanselminutes](https://www.hanselminutes.com/360/approval-tests-with-llewellyn-falco)
 - [Herding Code](https://www.developerfusion.com/media/122649/herding-code-117-llewellyn-falcon-on-approval-tests/)
-- [The Watir Podcast](https://watirpodcast.com/podcast-53/)
 
 
 

--- a/approvaltests-util/pom.xml
+++ b/approvaltests-util/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/approvaltests/pom.xml
+++ b/approvaltests/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/html_locker/pom.xml
+++ b/html_locker/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
It all started when I noticed that a large amount of the logs of the github actions contain "Downloaded from central: ...". 
So I went ahead and added caching to the github action for "run tests".
There are 2 benefits now from my side
* less noise in logs 
* bit faster test runs

Then I noticed that junit 4 is still using 4.12 but the current junit team recently released 4.13 so figured we could update to it.

And last but not least, I found a dead link in readme and looking at the website, they are gone for good.