### PR TITLE
Scrubber detecting date formats with offset like "yyyy-MM-dd'T'HH:mm'Z'"

### DIFF
--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.java
@@ -15,7 +15,12 @@ public class DateScrubberTests
                 "13 May 2014 23:50:49,999",
                 "May 13, 2014 11:30:00 PM PST",
                 "23:30:00",
-                "2014/05/13 16:30:59.786"};
+                "2014/05/13 16:30:59.786",
+                "2020-09-10T08:07Z",
+                "2020-9-10T08:07Z",
+                "2020-09-9T08:07Z",
+                "2020-09-10T8:07Z",
+        };
         Approvals.verifyAll("Date scrubbing", formats, this::verifyScrubbing);
     }
 

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.java
@@ -20,6 +20,7 @@ public class DateScrubberTests
                 "2020-9-10T08:07Z",
                 "2020-09-9T08:07Z",
                 "2020-09-10T8:07Z",
+                "2020-09-10T01:23:45.678Z"
         };
         Approvals.verifyAll("Date scrubbing", formats, this::verifyScrubbing);
     }

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.java
@@ -20,6 +20,7 @@ public class DateScrubberTests
                 "2020-9-10T08:07Z",
                 "2020-09-9T08:07Z",
                 "2020-09-10T8:07Z",
+                "2020-09-10T08:07:89Z",
                 "2020-09-10T01:23:45.678Z"
         };
         Approvals.verifyAll("Date scrubbing", formats, this::verifyScrubbing);

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
@@ -56,3 +56,8 @@ RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}Z]
 Example: {'date':"[Date1]"}
 
 
+Scrubbing for 2020-09-10T01:23:45.678Z:
+RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}\:\d{2}\.\d{3}Z]
+Example: {'date':"[Date1]"}
+
+

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
@@ -36,3 +36,23 @@ RegExScrubber[\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d.\d\d\d]
 Example: {'date':"[Date1]"}
 
 
+Scrubbing for 2020-09-10T08:07Z:
+RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}Z]
+Example: {'date':"[Date1]"}
+
+
+Scrubbing for 2020-9-10T08:07Z:
+RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}Z]
+Example: {'date':"[Date1]"}
+
+
+Scrubbing for 2020-09-9T08:07Z:
+RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}Z]
+Example: {'date':"[Date1]"}
+
+
+Scrubbing for 2020-09-10T8:07Z:
+RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}Z]
+Example: {'date':"[Date1]"}
+
+

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
@@ -56,6 +56,11 @@ RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}Z]
 Example: {'date':"[Date1]"}
 
 
+Scrubbing for 2020-09-10T08:07:89Z:
+RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}:\d{2}Z]
+Example: {'date':"[Date1]"}
+
+
 Scrubbing for 2020-09-10T01:23:45.678Z:
 RegExScrubber[\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}\:\d{2}\.\d{3}Z]
 Example: {'date':"[Date1]"}

--- a/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
+++ b/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
@@ -22,6 +22,7 @@ public class DateScrubber extends RegExScrubber {
                 "\\d\\d\\d\\d/\\d\\d/\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
+                "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}:\\d{2}Z",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}\\:\\d{2}\\.\\d{3}Z",
         };
         for (String pattern : possiblePatterns) {

--- a/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
+++ b/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
@@ -19,7 +19,9 @@ public class DateScrubber extends RegExScrubber {
                 "\\d\\d [a-zA-Z][a-zA-Z][a-zA-Z] \\d\\d\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d",
                 "[a-zA-Z][a-zA-Z][a-zA-Z] \\d\\d, \\d\\d\\d\\d \\d\\d:\\d\\d:\\d\\d [a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z]",
                 "\\d\\d:\\d\\d:\\d\\d",
-                "\\d\\d\\d\\d/\\d\\d/\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d"};
+                "\\d\\d\\d\\d/\\d\\d/\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
+                "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
+        };
         for (String pattern : possiblePatterns) {
             DateScrubber scrubber = new DateScrubber(pattern, n -> "[Date" + n + "]");
             if ("[Date1]".equals(scrubber.scrub(formattedExample))) {

--- a/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
+++ b/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
@@ -21,6 +21,8 @@ public class DateScrubber extends RegExScrubber {
                 "\\d\\d:\\d\\d:\\d\\d",
                 "\\d\\d\\d\\d/\\d\\d/\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
+                "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
+                "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}\\:\\d{2}\\.\\d{3}Z",
         };
         for (String pattern : possiblePatterns) {
             DateScrubber scrubber = new DateScrubber(pattern, n -> "[Date" + n + "]");


### PR DESCRIPTION
While tackling the [Product-Export-Refactoring-Kata](https://github.com/emilybache/Product-Export-Refactoring-Kata) I wanted to try out the new scrubbing feature we built, and it failed on me (exception with message 'No match found for 2020-09-10T08:07Z.'). I will use the RegExScrubber for now but I think those patterns are so common, it would be nice to support them out of the box.

Additional point to discuss: I used a slightly different way to specify the regex, limiting the digits: \\d vs \\d{4}

