### PR TITLE
Build on jdk 15 and 16 ea

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        java: ['8', '11', '14']
+        java: ['8', '11', '15', '16-ea']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '14']
+        java: ['8', '11', '15', '16-ea']
 
     steps:
     - uses: actions/checkout@v2

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.java
@@ -3,34 +3,31 @@ package org.approvaltests.scrubbers;
 import org.approvaltests.Approvals;
 import org.junit.jupiter.api.Test;
 
-import java.util.Iterator;
-
 public class DateScrubberTests
 {
-    @Test
-    void testGetDateScrubber() {
-        String[] formats = {"Tue May 13 16:30:00",
-                "Tue May 13 2014 23:30:00.789",
-                "Tue May 13 16:30:00 -0800 2014",
-                "13 May 2014 23:50:49,999",
-                "May 13, 2014 11:30:00 PM PST",
-                "23:30:00",
-                "2014/05/13 16:30:59.786",
-                "2020-09-10T08:07Z",
-                "2020-9-10T08:07Z",
-                "2020-09-9T08:07Z",
-                "2020-09-10T8:07Z",
-                "2020-09-10T08:07:89Z",
-                "2020-09-10T01:23:45.678Z"
-        };
-        Approvals.verifyAll("Date scrubbing", formats, this::verifyScrubbing);
-    }
-
-    private String verifyScrubbing(String formattedExample) {
-        DateScrubber scrubber = DateScrubber.getScrubberFor(formattedExample);
-        String exampleText = String.format("{'date':\"%s\"}",formattedExample);
-        return String.format("Scrubbing for %s:\n" +
-                "%s\n" +
-                "Example: %s\n\n", formattedExample, scrubber, scrubber.scrub(exampleText));
-    }
+  @Test
+  void testGetDateScrubber()
+  {
+    String[] formats = {"Tue May 13 16:30:00",
+                        "Tue May 13 2014 23:30:00.789",
+                        "Tue May 13 16:30:00 -0800 2014",
+                        "13 May 2014 23:50:49,999",
+                        "May 13, 2014 11:30:00 PM PST",
+                        "23:30:00",
+                        "2014/05/13 16:30:59.786",
+                        "2020-09-10T08:07Z",
+                        "2020-9-10T08:07Z",
+                        "2020-09-9T08:07Z",
+                        "2020-09-10T8:07Z",
+                        "2020-09-10T08:07:89Z",
+                        "2020-09-10T01:23:45.678Z"};
+    Approvals.verifyAll("Date scrubbing", formats, this::verifyScrubbing);
+  }
+  private String verifyScrubbing(String formattedExample)
+  {
+    DateScrubber scrubber = DateScrubber.getScrubberFor(formattedExample);
+    String exampleText = String.format("{'date':\"%s\"}", formattedExample);
+    return String.format("Scrubbing for %s:\n" + "%s\n" + "Example: %s\n\n", formattedExample, scrubber,
+        scrubber.scrub(exampleText));
+  }
 }

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
@@ -2,27 +2,27 @@ Date scrubbing
 
 
 Scrubbing for Tue May 13 16:30:00:
-RegExScrubber[[a-zA-Z][a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z] \d\d \d\d:\d\d:\d\d]
+RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d\d \d\d:\d\d:\d\d]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for Tue May 13 2014 23:30:00.789:
-RegExScrubber[[a-zA-Z][a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z] \d\d \d\d\d\d \d\d:\d\d:\d\d.\d\d\d]
+RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d\d \d{4} \d\d:\d\d:\d\d.\d\d\d]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for Tue May 13 16:30:00 -0800 2014:
-RegExScrubber[[a-zA-Z][a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z] \d\d \d\d:\d\d:\d\d -\d\d\d\d \d\d\d\d]
+RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d\d \d\d:\d\d:\d\d -\d{4} \d{4}]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for 13 May 2014 23:50:49,999:
-RegExScrubber[\d\d [a-zA-Z][a-zA-Z][a-zA-Z] \d\d\d\d \d\d:\d\d:\d\d,\d\d\d]
+RegExScrubber[\d\d [a-zA-Z]{3} \d{4} \d\d:\d\d:\d\d,\d\d\d]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for May 13, 2014 11:30:00 PM PST:
-RegExScrubber[[a-zA-Z][a-zA-Z][a-zA-Z] \d\d, \d\d\d\d \d\d:\d\d:\d\d [a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z]]
+RegExScrubber[[a-zA-Z]{3} \d\d, \d{4} \d\d:\d\d:\d\d [a-zA-Z][a-zA-Z] [a-zA-Z]{3}]
 Example: {'date':"[Date1]"}
 
 
@@ -32,7 +32,7 @@ Example: {'date':"[Date1]"}
 
 
 Scrubbing for 2014/05/13 16:30:59.786:
-RegExScrubber[\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d.\d\d\d]
+RegExScrubber[\d{4}/\d\d/\d\d \d\d:\d\d:\d\d.\d\d\d]
 Example: {'date':"[Date1]"}
 
 

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
@@ -2,37 +2,37 @@ Date scrubbing
 
 
 Scrubbing for Tue May 13 16:30:00:
-RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d\d \d\d:\d\d:\d\d]
+RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{2}:\d{2}:\d{2}]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for Tue May 13 2014 23:30:00.789:
-RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d\d \d{4} \d\d:\d\d:\d\d.\d\d\d]
+RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{4} \d{2}:\d{2}:\d{2}.\d{2}\d]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for Tue May 13 16:30:00 -0800 2014:
-RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d\d \d\d:\d\d:\d\d -\d{4} \d{4}]
+RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{2}:\d{2}:\d{2} -\d{4} \d{4}]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for 13 May 2014 23:50:49,999:
-RegExScrubber[\d\d [a-zA-Z]{3} \d{4} \d\d:\d\d:\d\d,\d\d\d]
+RegExScrubber[\d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2},\d{2}\d]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for May 13, 2014 11:30:00 PM PST:
-RegExScrubber[[a-zA-Z]{3} \d\d, \d{4} \d\d:\d\d:\d\d [a-zA-Z][a-zA-Z] [a-zA-Z]{3}]
+RegExScrubber[[a-zA-Z]{3} \d{2}, \d{4} \d{2}:\d{2}:\d{2} [a-zA-Z][a-zA-Z] [a-zA-Z]{3}]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for 23:30:00:
-RegExScrubber[\d\d:\d\d:\d\d]
+RegExScrubber[\d{2}:\d{2}:\d{2}]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for 2014/05/13 16:30:59.786:
-RegExScrubber[\d{4}/\d\d/\d\d \d\d:\d\d:\d\d.\d\d\d]
+RegExScrubber[\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}.\d{2}\d]
 Example: {'date':"[Date1]"}
 
 

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTests.testGetDateScrubber.approved.txt
@@ -7,7 +7,7 @@ Example: {'date':"[Date1]"}
 
 
 Scrubbing for Tue May 13 2014 23:30:00.789:
-RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{4} \d{2}:\d{2}:\d{2}.\d{2}\d]
+RegExScrubber[[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{4} \d{2}:\d{2}:\d{2}.\d{3}]
 Example: {'date':"[Date1]"}
 
 
@@ -17,12 +17,12 @@ Example: {'date':"[Date1]"}
 
 
 Scrubbing for 13 May 2014 23:50:49,999:
-RegExScrubber[\d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2},\d{2}\d]
+RegExScrubber[\d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2},\d{3}]
 Example: {'date':"[Date1]"}
 
 
 Scrubbing for May 13, 2014 11:30:00 PM PST:
-RegExScrubber[[a-zA-Z]{3} \d{2}, \d{4} \d{2}:\d{2}:\d{2} [a-zA-Z][a-zA-Z] [a-zA-Z]{3}]
+RegExScrubber[[a-zA-Z]{3} \d{2}, \d{4} \d{2}:\d{2}:\d{2} [a-zA-Z]{2} [a-zA-Z]{3}]
 Example: {'date':"[Date1]"}
 
 

--- a/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
+++ b/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
@@ -1,41 +1,43 @@
 package org.approvaltests.scrubbers;
 
-import com.spun.util.FormattedException;
+import java.util.Arrays;
+
 import org.lambda.functions.Function1;
 
-import java.util.Arrays;
-import java.util.regex.Pattern;
+import com.spun.util.FormattedException;
 
-public class DateScrubber extends RegExScrubber {
-
-    public DateScrubber(String pattern, Function1<Integer, String> replacement) {
-        super(pattern, replacement);
+public class DateScrubber extends RegExScrubber
+{
+  public DateScrubber(String pattern, Function1<Integer, String> replacement)
+  {
+    super(pattern, replacement);
+  }
+  public static DateScrubber getScrubberFor(String formattedExample)
+  {
+    String possiblePatterns[] = {"[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{2}:\\d{2}:\\d{2}",
+                                 "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{4} \\d{2}:\\d{2}:\\d{2}.\\d{3}",
+                                 "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{2}:\\d{2}:\\d{2} -\\d{4} \\d{4}",
+                                 "\\d{2} [a-zA-Z]{3} \\d{4} \\d{2}:\\d{2}:\\d{2},\\d{3}",
+                                 "[a-zA-Z]{3} \\d{2}, \\d{4} \\d{2}:\\d{2}:\\d{2} [a-zA-Z]{2} [a-zA-Z]{3}",
+                                 "\\d{2}:\\d{2}:\\d{2}",
+                                 "\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{2}\\d",
+                                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
+                                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
+                                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}:\\d{2}Z",
+                                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}\\:\\d{2}\\.\\d{3}Z",};
+    for (String pattern : possiblePatterns)
+    {
+      DateScrubber scrubber = new DateScrubber(pattern, n -> "[Date" + n + "]");
+      if ("[Date1]".equals(scrubber.scrub(formattedExample)))
+      { return scrubber; }
     }
-
-    public static DateScrubber getScrubberFor(String formattedExample) {
-      String possiblePatterns[] = {"[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{2}:\\d{2}:\\d{2}",
-                "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{4} \\d{2}:\\d{2}:\\d{2}.\\d{3}",
-                "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{2}:\\d{2}:\\d{2} -\\d{4} \\d{4}",
-                "\\d{2} [a-zA-Z]{3} \\d{4} \\d{2}:\\d{2}:\\d{2},\\d{3}",
-                "[a-zA-Z]{3} \\d{2}, \\d{4} \\d{2}:\\d{2}:\\d{2} [a-zA-Z]{2} [a-zA-Z]{3}",
-                "\\d{2}:\\d{2}:\\d{2}",
-                "\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{2}\\d",
-                "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
-                "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
-                "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}:\\d{2}Z",
-                "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}\\:\\d{2}\\.\\d{3}Z",
-        };
-        for (String pattern : possiblePatterns) {
-            DateScrubber scrubber = new DateScrubber(pattern, n -> "[Date" + n + "]");
-            if ("[Date1]".equals(scrubber.scrub(formattedExample))) {
-                return scrubber;
-            }
-        }
-        throw new FormattedException("No match found for %s.\n Current supported formats are: %s", formattedExample, Arrays.asList(possiblePatterns));
-    }
-
-    @Override
-    public String toString() {
-        return super.toString();
-    }
+    throw new FormattedException(
+        "No match found for %s.\n Feel free to add your date at https://github.com/approvals/ApprovalTests.Java/issues/112 \n Current supported formats are: %s",
+        formattedExample, Arrays.asList(possiblePatterns));
+  }
+  @Override
+  public String toString()
+  {
+    return super.toString();
+  }
 }

--- a/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
+++ b/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
@@ -13,13 +13,13 @@ public class DateScrubber extends RegExScrubber {
     }
 
     public static DateScrubber getScrubberFor(String formattedExample) {
-        String possiblePatterns[] = {"[a-zA-Z][a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z] \\d\\d \\d\\d:\\d\\d:\\d\\d",
-                "[a-zA-Z][a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z] \\d\\d \\d\\d\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
-                "[a-zA-Z][a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z] \\d\\d \\d\\d:\\d\\d:\\d\\d -\\d\\d\\d\\d \\d\\d\\d\\d",
-                "\\d\\d [a-zA-Z][a-zA-Z][a-zA-Z] \\d\\d\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d",
-                "[a-zA-Z][a-zA-Z][a-zA-Z] \\d\\d, \\d\\d\\d\\d \\d\\d:\\d\\d:\\d\\d [a-zA-Z][a-zA-Z] [a-zA-Z][a-zA-Z][a-zA-Z]",
+      String possiblePatterns[] = {"[a-zA-Z]{3} [a-zA-Z]{3} \\d\\d \\d\\d:\\d\\d:\\d\\d",
+                "[a-zA-Z]{3} [a-zA-Z]{3} \\d\\d \\d{4} \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
+                "[a-zA-Z]{3} [a-zA-Z]{3} \\d\\d \\d\\d:\\d\\d:\\d\\d -\\d{4} \\d{4}",
+                "\\d\\d [a-zA-Z]{3} \\d{4} \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d",
+                "[a-zA-Z]{3} \\d\\d, \\d{4} \\d\\d:\\d\\d:\\d\\d [a-zA-Z][a-zA-Z] [a-zA-Z]{3}",
                 "\\d\\d:\\d\\d:\\d\\d",
-                "\\d\\d\\d\\d/\\d\\d/\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
+                "\\d{4}/\\d\\d/\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}:\\d{2}Z",

--- a/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
+++ b/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
@@ -14,10 +14,10 @@ public class DateScrubber extends RegExScrubber {
 
     public static DateScrubber getScrubberFor(String formattedExample) {
       String possiblePatterns[] = {"[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{2}:\\d{2}:\\d{2}",
-                "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{4} \\d{2}:\\d{2}:\\d{2}.\\d{2}\\d",
+                "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{4} \\d{2}:\\d{2}:\\d{2}.\\d{3}",
                 "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{2}:\\d{2}:\\d{2} -\\d{4} \\d{4}",
-                "\\d{2} [a-zA-Z]{3} \\d{4} \\d{2}:\\d{2}:\\d{2},\\d{2}\\d",
-                "[a-zA-Z]{3} \\d{2}, \\d{4} \\d{2}:\\d{2}:\\d{2} [a-zA-Z][a-zA-Z] [a-zA-Z]{3}",
+                "\\d{2} [a-zA-Z]{3} \\d{4} \\d{2}:\\d{2}:\\d{2},\\d{3}",
+                "[a-zA-Z]{3} \\d{2}, \\d{4} \\d{2}:\\d{2}:\\d{2} [a-zA-Z]{2} [a-zA-Z]{3}",
                 "\\d{2}:\\d{2}:\\d{2}",
                 "\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{2}\\d",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",

--- a/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
+++ b/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
@@ -13,13 +13,13 @@ public class DateScrubber extends RegExScrubber {
     }
 
     public static DateScrubber getScrubberFor(String formattedExample) {
-      String possiblePatterns[] = {"[a-zA-Z]{3} [a-zA-Z]{3} \\d\\d \\d\\d:\\d\\d:\\d\\d",
-                "[a-zA-Z]{3} [a-zA-Z]{3} \\d\\d \\d{4} \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
-                "[a-zA-Z]{3} [a-zA-Z]{3} \\d\\d \\d\\d:\\d\\d:\\d\\d -\\d{4} \\d{4}",
-                "\\d\\d [a-zA-Z]{3} \\d{4} \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d",
-                "[a-zA-Z]{3} \\d\\d, \\d{4} \\d\\d:\\d\\d:\\d\\d [a-zA-Z][a-zA-Z] [a-zA-Z]{3}",
-                "\\d\\d:\\d\\d:\\d\\d",
-                "\\d{4}/\\d\\d/\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d",
+      String possiblePatterns[] = {"[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{2}:\\d{2}:\\d{2}",
+                "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{4} \\d{2}:\\d{2}:\\d{2}.\\d{2}\\d",
+                "[a-zA-Z]{3} [a-zA-Z]{3} \\d{2} \\d{2}:\\d{2}:\\d{2} -\\d{4} \\d{4}",
+                "\\d{2} [a-zA-Z]{3} \\d{4} \\d{2}:\\d{2}:\\d{2},\\d{2}\\d",
+                "[a-zA-Z]{3} \\d{2}, \\d{4} \\d{2}:\\d{2}:\\d{2} [a-zA-Z][a-zA-Z] [a-zA-Z]{3}",
+                "\\d{2}:\\d{2}:\\d{2}",
+                "\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{2}\\d",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}Z",
                 "\\d{4}-\\d{1,2}-\\d{1,2}T\\d{1,2}:\\d{2}:\\d{2}Z",


### PR DESCRIPTION
jdk 14 is not the current/latest anymore, so lets drop running tests on 14 but on 15 instead. And adding JDK 16 early access. We should think about contacting the OpenJDK Quality Group at https://wiki.openjdk.java.net/display/quality/Quality+Outreach to get added to the list. What do you think?