### PR TITLE
update the URL to the approvaltests website

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The suggested fix is to add
 ## More Info
 
 
-- [Website](https://approvaltests.org/)
+- [Website](https://approvaltests.com/)
 - [Blog](https://blog.approvaltests.org/)
 - [Getting Started Doc](https://github.com/approvals/ApprovalTests.Java/blob/master/build/resources/approval_tests/documentation/ApprovalTests%20-%20GettingStarted.md)
 


### PR DESCRIPTION
The actual url seems to be broken: I replaced it with https://approvaltests.com.