### PR TITLE
Optionally create approved file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target
 .vscode/
 build/venv*/
 __pycache__/
+
+approvaltests-tests/src/test/java/org/approvaltests/OptionsTest.verifyFileApprovedFileCreation.approved.txt

--- a/approvaltests-tests/src/test/java/org/approvaltests/OptionsTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/OptionsTest.java
@@ -125,6 +125,13 @@ public class OptionsTest
     Approvals.verify(sampleText, new Options().forFile().withName("customApproval", ".html"));
     Approvals.verify(sampleText, new Options().forFile().withBaseName("customApproval"));
   }
+  @Test
+  void verifyFileApprovedFileCreation()
+  {
+    String sampleText = "<html><body><h1>hello approvals</h1></body></html>";
+    Approvals.verify(sampleText,
+        new Options().forFile().withCreateApprovedFileIfNoneExisting(true));
+  }
   @Disabled("todo")
   @Test
   void verifyFilePath()

--- a/approvaltests-tests/src/test/java/org/approvaltests/approvers/FileApproverTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/approvers/FileApproverTest.java
@@ -13,6 +13,7 @@ import org.approvaltests.namer.ApprovalNamer;
 import org.approvaltests.writers.ApprovalTextWriter;
 import org.junit.jupiter.api.Test;
 import org.lambda.functions.Function2;
+import org.lambda.functions.Function3;
 
 import com.spun.util.ObjectUtils;
 import com.spun.util.io.FileUtils;
@@ -33,9 +34,9 @@ public class FileApproverTest
   {
     File f1 = createFile("1");
     File f2 = createFile("2");
-    assertFalse(FileApprover.approveTextFile(f2, f1), "files are different");
+    assertFalse(FileApprover.approveTextFile(f2, f1, false), "files are different");
     f2 = createFile("1");
-    assertTrue(FileApprover.approveTextFile(f2, f1), "files are the same");
+    assertTrue(FileApprover.approveTextFile(f2, f1, false), "files are the same");
   }
   @Test
   public void testApproveTextFileWithNonExsitantFile()
@@ -44,7 +45,18 @@ public class FileApproverTest
     File f2 = new File("no exist");
     assertTrue(f1.exists());
     assertFalse(f2.exists());
-    assertFalse(FileApprover.approveTextFile(f2, f1));
+    assertFalse(FileApprover.approveTextFile(f2, f1, false));
+  }
+  @Test
+  public void testApproveTextFileWithNonExsitantFileCreated()
+  {
+    File received = createFile("1");
+    File approved = new File("no-exist");
+    assertTrue(received.exists());
+    assertFalse(approved.exists());
+    assertTrue(FileApprover.approveTextFile(received, approved, true));
+    assertTrue(approved.exists());
+    assertTrue(approved.delete());
   }
   private File createFile(String string)
   {
@@ -65,8 +77,8 @@ public class FileApproverTest
     // begin-snippet: custom_approver
     ApprovalTextWriter writer = new ApprovalTextWriter("Random: ", new Options());
     ApprovalNamer namer = Approvals.createApprovalNamer();
-    Function2<File, File, Boolean> approveEverything = (r, a) -> true;
-    Approvals.verify(new FileApprover(writer, namer, approveEverything));
+    Function3<File, File, Boolean, Boolean> approveEverything = (r, a, b) -> true;
+    Approvals.verify(new FileApprover(writer, namer, approveEverything, new Options()));
     // end-snippet
   }
 }

--- a/approvaltests/src/main/java/org/approvaltests/Approvals.java
+++ b/approvaltests/src/main/java/org/approvaltests/Approvals.java
@@ -159,7 +159,8 @@ public class Approvals
   @Deprecated
   public static void verify(ApprovalWriter writer, ApprovalNamer namer, ApprovalFailureReporter reporter)
   {
-    verify(new FileApprover(writer, namer), new Options(reporter));
+    Options options = new Options(reporter);
+    verify(new FileApprover(writer, namer, options), options);
   }
   public static void verify(ApprovalWriter writer, ApprovalNamer namer)
   {
@@ -167,7 +168,7 @@ public class Approvals
   }
   public static void verify(ApprovalWriter writer, ApprovalNamer namer, Options options)
   {
-    verify(new FileApprover(writer, namer), options);
+    verify(new FileApprover(writer, namer, options), options);
   }
   public static void verify(ApprovalWriter writer)
   {

--- a/approvaltests/src/main/java/org/approvaltests/approvers/FileApprover.java
+++ b/approvaltests/src/main/java/org/approvaltests/approvers/FileApprover.java
@@ -5,8 +5,10 @@ import java.io.File;
 import org.approvaltests.core.ApprovalFailureReporter;
 import org.approvaltests.core.ApprovalReporterWithCleanUp;
 import org.approvaltests.core.ApprovalWriter;
+import org.approvaltests.core.Options;
 import org.approvaltests.namer.ApprovalNamer;
 import org.lambda.functions.Function2;
+import org.lambda.functions.Function3;
 
 import com.spun.util.ObjectUtils;
 import com.spun.util.io.FileUtils;
@@ -16,23 +18,25 @@ public class FileApprover implements ApprovalApprover
   private File                           received;
   private File                           approved;
   private final ApprovalWriter           writer;
-  private Function2<File, File, Boolean> approver;
-  public FileApprover(ApprovalWriter writer, ApprovalNamer namer)
+  private Function3<File, File, Boolean, Boolean> approver;
+  private Options                        options;
+  public FileApprover(ApprovalWriter writer, ApprovalNamer namer, Options options)
   {
-    this(writer, namer, FileApprover::approveTextFile);
+    this(writer, namer, FileApprover::approveTextFile, options);
   }
-  public FileApprover(ApprovalWriter writer, ApprovalNamer namer, Function2<File, File, Boolean> approver)
+  public FileApprover(ApprovalWriter writer, ApprovalNamer namer, Function3<File, File, Boolean, Boolean> approver, Options options)
   {
     this.writer = writer;
     String base = String.format("%s%s", namer.getSourceFilePath(), namer.getApprovalName());
     received = new File(writer.getReceivedFilename(base));
     approved = new File(writer.getApprovalFilename(base));
     this.approver = approver;
+    this.options = options;
   }
   public boolean approve()
   {
     received = new File(writer.writeReceivedFile(received.getAbsolutePath()));
-    return approver.call(received, approved);
+    return approver.call(received, approved, options.forFile().shouldCreateApprovedFileIfNoneExisting());
   }
   public void cleanUpAfterSuccess(ApprovalFailureReporter reporter)
   {
@@ -51,11 +55,19 @@ public class FileApprover implements ApprovalApprover
     throw new Error(String.format("Failed Approval\n  Approved:%s\n  Received:%s", approved.getAbsolutePath(),
         received.getAbsolutePath()));
   }
-  public static Boolean approveTextFile(File received, File approved)
+  public static Boolean approveTextFile(File received, File approved, Boolean shouldCreateApprovedFileIfNoneExisting)
   {
-    if (!approved.exists() || !received.exists()) { return false; }
-    String t1 = FileUtils.readFile(approved);
-    String t2 = FileUtils.readFile(received);
-    return ObjectUtils.isEqual(t1, t2);
+    if (!shouldCreateApprovedFileIfNoneExisting && !approved.exists() || !received.exists()) {
+        return false;
+    }
+    if (approved.exists()) {
+        String t1 = FileUtils.readFile(approved);
+        String t2 = FileUtils.readFile(received);
+        return ObjectUtils.isEqual(t1, t2);
+    } else {
+        String data = FileUtils.readFile(received);
+        FileUtils.writeFile(approved, data);
+        return true;
+    }
   }
 }

--- a/approvaltests/src/main/java/org/approvaltests/core/Options.java
+++ b/approvaltests/src/main/java/org/approvaltests/core/Options.java
@@ -58,6 +58,7 @@ public class Options
   public static class FileOptions
   {
     private String         fileExtension = ".txt";
+    private boolean        createApprovedFileIfNoneExisting = false;
     protected NamerWrapper approvalNamer = null;
     protected Options      parent;
     public FileOptions()
@@ -67,10 +68,11 @@ public class Options
     {
       this.fileExtension = fileExtension;
     }
-    public FileOptions(NamerWrapper approvalNamer, String fileExtension)
+    public FileOptions(NamerWrapper approvalNamer, String fileExtension, boolean createApprovedFileIfNoneExisting)
     {
       this.approvalNamer = approvalNamer;
       this.fileExtension = fileExtension;
+      this.createApprovedFileIfNoneExisting = createApprovedFileIfNoneExisting;
     }
     public void setParent(Options parent)
     {
@@ -82,7 +84,7 @@ public class Options
       {
         fileExtensionWithDot = "." + fileExtensionWithDot;
       }
-      FileOptions f = new FileOptions(this.approvalNamer, fileExtensionWithDot);
+      FileOptions f = new FileOptions(this.approvalNamer, fileExtensionWithDot, createApprovedFileIfNoneExisting);
       return new Options(parent, f);
     }
     public ApprovalNamer getNamer()
@@ -93,16 +95,24 @@ public class Options
     {
       return fileExtension;
     }
+    public boolean shouldCreateApprovedFileIfNoneExisting() {
+		return createApprovedFileIfNoneExisting;
+	}
     public Options withBaseName(String fileBaseName)
     {
       NamerWrapper approvalNamer = new NamerWrapper(() -> fileBaseName, getNamer());
-      FileOptions f = new FileOptions(approvalNamer, this.fileExtension);
+      FileOptions f = new FileOptions(approvalNamer, this.fileExtension, createApprovedFileIfNoneExisting);
       return new Options(parent, f);
     }
 
     public Options withName(String fileBaseName, String extension) {
       NamerWrapper approvalNamer = new NamerWrapper(() -> fileBaseName, getNamer());
-      FileOptions f = new FileOptions(approvalNamer, extension);
+      FileOptions f = new FileOptions(approvalNamer, extension, createApprovedFileIfNoneExisting);
+      return new Options(parent, f);
+    }
+
+    public Options withCreateApprovedFileIfNoneExisting(boolean createApprovedFileIfNoneExisting) {
+      FileOptions f = new FileOptions(approvalNamer, fileExtension, createApprovedFileIfNoneExisting);
       return new Options(parent, f);
     }
   }

--- a/html_locker/src/main/java/org/approvaltests/webpages/WebPageChangeDetector.java
+++ b/html_locker/src/main/java/org/approvaltests/webpages/WebPageChangeDetector.java
@@ -68,7 +68,7 @@ public class WebPageChangeDetector implements ActionListener
   }
   private boolean verifyFiles(String approvedFile, String recievedFile)
   {
-    return FileApprover.approveTextFile(new File(recievedFile), new File(approvedFile));
+    return FileApprover.approveTextFile(new File(recievedFile), new File(approvedFile), false);
   }
   private String getRecievedFile()
   {


### PR DESCRIPTION
## Description

I prefer approving changes using `git diff`, not by analyzing failed tests and renaming files. I feel it is faster to just record results and perform `git diff`.

## The solution

I added an optional behavior in the `FileOptions` class. It will:

 * Always pass any test when approved file does not exist.
 * Create the approved file if it does not exist.
 * Fail only if the approved file exist, and differs from received file.

With this change, I can do:

```bash
find -name "*.approved.*" | xargs rm \
 && mvn test
```

And inspect all changes with:
```bash
git diff
```
