### PR TITLE
Flaky approvals

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -85,9 +85,10 @@ public class AttributeStackSelector implements StackElementSelector
     List<Method> methods = getMethodsByName(clazz, methodName);
     if (methods.isEmpty())
     { return false; }
+    Method method = methods.get(0);
     for (Class<? extends Annotation> attribute : attributes)
     {
-      if (methods.get(0).isAnnotationPresent(attribute))
+      if (method.isAnnotationPresent(attribute))
       { return true; }
     }
     return false;

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.spun.util.ObjectUtils;
 import com.spun.util.io.StackElementSelector;
@@ -100,13 +101,7 @@ public class AttributeStackSelector implements StackElementSelector
     try
     {
       Method[] declaredMethods = clazz.getDeclaredMethods();
-      for (Method m : declaredMethods)
-      {
-        if (m.getName().equals(methodName))
-        {
-          methods.add(m);
-        }
-      }
+      methods = Arrays.stream(declaredMethods).filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
     }
     catch (Throwable e)
     {

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -3,6 +3,7 @@ package org.approvaltests.namer;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.spun.util.ObjectUtils;
@@ -81,7 +82,7 @@ public class AttributeStackSelector implements StackElementSelector
   private boolean isTestAttribute(Class<?> clazz, String methodName)
       throws ClassNotFoundException, SecurityException
   {
-    Method method = getMethodByName(clazz, methodName);
+    Method method = getMethodByName(clazz, methodName).get(0);
     if (method == null)
     { return false; }
     for (Class<? extends Annotation> attribute : attributes)
@@ -91,7 +92,7 @@ public class AttributeStackSelector implements StackElementSelector
     }
     return false;
   }
-  public Method getMethodByName(Class<?> clazz, String methodName)
+  public List<Method> getMethodByName(Class<?> clazz, String methodName)
   {
     Method method = null;
     try
@@ -108,7 +109,7 @@ public class AttributeStackSelector implements StackElementSelector
     catch (Throwable e)
     {
     }
-    return method;
+    return Arrays.asList(method);
   }
   @Override
   public void increment()

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -100,8 +100,7 @@ public class AttributeStackSelector implements StackElementSelector
     List<Method> methods = new ArrayList<>();
     try
     {
-      Method[] declaredMethods = clazz.getDeclaredMethods();
-      methods = Arrays.stream(declaredMethods).filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
+      methods = Arrays.stream(clazz.getDeclaredMethods()).filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
     }
     catch (Throwable e)
     {

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -82,19 +82,19 @@ public class AttributeStackSelector implements StackElementSelector
   private boolean isTestAttribute(Class<?> clazz, String methodName)
       throws ClassNotFoundException, SecurityException
   {
-    Method method = getMethodsByName(clazz, methodName).get(0);
-    if (method == null)
+    List<Method> methods = getMethodsByName(clazz, methodName);
+    if (methods.isEmpty())
     { return false; }
     for (Class<? extends Annotation> attribute : attributes)
     {
-      if (method.isAnnotationPresent(attribute))
+      if (methods.get(0).isAnnotationPresent(attribute))
       { return true; }
     }
     return false;
   }
   public List<Method> getMethodsByName(Class<?> clazz, String methodName)
   {
-    Method method = null;
+    List<Method> methods = new ArrayList<>();
     try
     {
       Method[] declaredMethods = clazz.getDeclaredMethods();
@@ -102,14 +102,14 @@ public class AttributeStackSelector implements StackElementSelector
       {
         if (m.getName().equals(methodName))
         {
-          method = m;
+          methods.add(m);
         }
       }
     }
     catch (Throwable e)
     {
     }
-    return Arrays.asList(method);
+    return methods;
   }
   @Override
   public void increment()

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -82,7 +82,7 @@ public class AttributeStackSelector implements StackElementSelector
   private boolean isTestAttribute(Class<?> clazz, String methodName)
       throws ClassNotFoundException, SecurityException
   {
-    Method method = getMethodByName(clazz, methodName).get(0);
+    Method method = getMethodsByName(clazz, methodName).get(0);
     if (method == null)
     { return false; }
     for (Class<? extends Annotation> attribute : attributes)
@@ -92,7 +92,7 @@ public class AttributeStackSelector implements StackElementSelector
     }
     return false;
   }
-  public List<Method> getMethodByName(Class<?> clazz, String methodName)
+  public List<Method> getMethodsByName(Class<?> clazz, String methodName)
   {
     Method method = null;
     try

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -99,7 +99,9 @@ public class AttributeStackSelector implements StackElementSelector
   {
     try
     {
-      return  Arrays.stream(clazz.getDeclaredMethods()).filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
+      return  Arrays.stream(clazz.getDeclaredMethods())
+                    .filter(m -> m.getName().equals(methodName))
+                    .collect(Collectors.toList());
     }
     catch (Throwable e)
     {

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -97,16 +97,14 @@ public class AttributeStackSelector implements StackElementSelector
   }
   public List<Method> getMethodsByName(Class<?> clazz, String methodName)
   {
-    List<Method> methods = new ArrayList<>();
     try
     {
-      methods = Arrays.stream(clazz.getDeclaredMethods()).filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
+      return  Arrays.stream(clazz.getDeclaredMethods()).filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
     }
     catch (Throwable e)
     {
       return new ArrayList<>();
     }
-    return methods;
   }
   @Override
   public void increment()

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -85,11 +85,12 @@ public class AttributeStackSelector implements StackElementSelector
     List<Method> methods = getMethodsByName(clazz, methodName);
     if (methods.isEmpty())
     { return false; }
-    Method method = methods.get(0);
-    for (Class<? extends Annotation> attribute : attributes)
-    {
-      if (method.isAnnotationPresent(attribute))
-      { return true; }
+    for (Method method : methods) {
+      for (Class<? extends Annotation> attribute : attributes)
+      {
+        if (method.isAnnotationPresent(attribute))
+        { return true; }
+      }
     }
     return false;
   }

--- a/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/AttributeStackSelector.java
@@ -104,6 +104,7 @@ public class AttributeStackSelector implements StackElementSelector
     }
     catch (Throwable e)
     {
+      return new ArrayList<>();
     }
     return methods;
   }

--- a/approvaltests/src/test/java/org/approvaltests/namer/AttributeStackSelectorTest.java
+++ b/approvaltests/src/test/java/org/approvaltests/namer/AttributeStackSelectorTest.java
@@ -14,9 +14,8 @@ public class AttributeStackSelectorTest {
 
     // these methods are overloads of the test method
     // to simulate flaky failures
-    // will be enabled after refactor
-//    public void selectElement(String unused) { }
-//    public void selectElement(Integer unused) { }
-//    public void selectElement(AttributeStackSelectorTest unused) { }
-//    public void selectElement(StackTraceElement unused) { }
+    public void selectElement(String unused) { }
+    public void selectElement(Integer unused) { }
+    public void selectElement(AttributeStackSelectorTest unused) { }
+    public void selectElement(StackTraceElement unused) { }
 }

--- a/approvaltests/src/test/java/org/approvaltests/namer/AttributeStackSelectorTest.java
+++ b/approvaltests/src/test/java/org/approvaltests/namer/AttributeStackSelectorTest.java
@@ -1,0 +1,22 @@
+package org.approvaltests.namer;
+
+import com.spun.util.ThreadUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AttributeStackSelectorTest {
+    @Test
+    public void selectElement() throws Exception {
+        AttributeStackSelector selector = new AttributeStackSelector();
+        StackTraceElement[] stackTrace = ThreadUtils.getStackTrace();
+        Assert.assertEquals(stackTrace[2], selector.selectElement(stackTrace));
+    }
+
+    // these methods are overloads of the test method
+    // to simulate flaky failures
+    // will be enabled after refactor
+//    public void selectElement(String unused) { }
+//    public void selectElement(Integer unused) { }
+//    public void selectElement(AttributeStackSelectorTest unused) { }
+//    public void selectElement(StackTraceElement unused) { }
+}


### PR DESCRIPTION
## Description
This PR fixes issue #151

## The solution

Change `AttributeStackSelector.getMethodsByName` to return all overloads with the same name.

## Notation

I did lots of very small commits prefixed with [Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md), as requested.

## Remarks

I couldn't get the whole project to build on my machine, so I focused on the `approvaltests` module only.
