### PR TITLE
B!! use linux.DiffMergeReporter instead macosx version on Linux

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/reporters/linux/LinuxDiffReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/linux/LinuxDiffReporter.java
@@ -2,7 +2,6 @@ package org.approvaltests.reporters.linux;
 
 import org.approvaltests.reporters.FirstWorkingReporter;
 import org.approvaltests.reporters.intellij.IntelliJReporter;
-import org.approvaltests.reporters.macosx.DiffMergeReporter;
 
 public class LinuxDiffReporter extends FirstWorkingReporter
 {


### PR DESCRIPTION
I think there was an accidental import, but we want the Linux version in this place.


