### PR TITLE
Refactor remove Optional from argument/field in Options

### DIFF
--- a/approvaltests-tests/src/test/java/org/approvaltests/OptionsTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/OptionsTest.java
@@ -3,6 +3,7 @@ package org.approvaltests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -12,6 +13,7 @@ import java.util.List;
 import org.approvaltests.combinations.CombinationApprovals;
 import org.approvaltests.core.ApprovalFailureReporter;
 import org.approvaltests.core.Options;
+import org.approvaltests.core.Scrubber;
 import org.approvaltests.reporters.FirstWorkingReporter;
 import org.approvaltests.reporters.UseReporter;
 import org.approvaltests.reporters.UseReporterTest;
@@ -24,6 +26,20 @@ import com.spun.util.ArrayUtils;
 
 public class OptionsTest
 {
+  @Test
+  void cannotInstantiateWithoutScrubber()
+  {
+    Scrubber nullScrubber = null;
+    assertThrows(NullPointerException.class, () -> new Options(nullScrubber));
+    assertThrows(NullPointerException.class, () -> new Options().withScrubber(nullScrubber));
+  }
+  @Test
+  void cannotInstantiateWithoutReporter()
+  {
+    ApprovalFailureReporter nullReporter = null;
+    assertThrows(NullPointerException.class, () -> new Options(nullReporter));
+    assertThrows(NullPointerException.class, () -> new Options().withReporter(nullReporter));
+  }
   @Test
   void verifyWithReporterInOptions()
   {

--- a/approvaltests/src/main/java/org/approvaltests/core/Options.java
+++ b/approvaltests/src/main/java/org/approvaltests/core/Options.java
@@ -1,7 +1,5 @@
 package org.approvaltests.core;
 
-import java.util.Optional;
-
 import org.approvaltests.Approvals;
 import org.approvaltests.ReporterFactory;
 import org.approvaltests.namer.ApprovalNamer;
@@ -10,9 +8,9 @@ import org.approvaltests.scrubbers.NoOpScrubber;
 
 public class Options
 {
-  private Scrubber                          scrubber    = NoOpScrubber.INSTANCE;
-  private Optional<ApprovalFailureReporter> reporter    = Optional.empty();
-  private FileOptions                       fileOptions = new FileOptions();
+  private Scrubber                scrubber    = NoOpScrubber.INSTANCE;
+  private ApprovalFailureReporter reporter    = ReporterFactory.get();
+  private FileOptions             fileOptions = new FileOptions();
   public Options()
   {
   }
@@ -22,9 +20,9 @@ public class Options
   }
   public Options(ApprovalFailureReporter reporter)
   {
-    this.reporter = Optional.ofNullable(reporter);
+    this.reporter = reporter;
   }
-  private Options(Scrubber scrubber, Optional<ApprovalFailureReporter> reporter, FileOptions fileOptions)
+  private Options(Scrubber scrubber, ApprovalFailureReporter reporter, FileOptions fileOptions)
   {
     this.scrubber = scrubber;
     this.reporter = reporter;
@@ -36,11 +34,11 @@ public class Options
   }
   public ApprovalFailureReporter getReporter()
   {
-    return this.reporter.orElse(ReporterFactory.get());
+    return this.reporter;
   }
   public Options withReporter(ApprovalFailureReporter reporter)
   {
-    return new Options(this.scrubber, Optional.ofNullable(reporter), fileOptions);
+    return new Options(this.scrubber, reporter, fileOptions);
   }
   public Options withScrubber(Scrubber scrubber)
   {

--- a/approvaltests/src/main/java/org/approvaltests/core/Options.java
+++ b/approvaltests/src/main/java/org/approvaltests/core/Options.java
@@ -6,6 +6,8 @@ import org.approvaltests.namer.ApprovalNamer;
 import org.approvaltests.namer.NamerWrapper;
 import org.approvaltests.scrubbers.NoOpScrubber;
 
+import java.util.Objects;
+
 public class Options
 {
   private Scrubber                scrubber    = NoOpScrubber.INSTANCE;
@@ -16,10 +18,12 @@ public class Options
   }
   public Options(Scrubber scrubber)
   {
+    Objects.requireNonNull(scrubber, "need to provide a scrubber");
     this.scrubber = scrubber;
   }
   public Options(ApprovalFailureReporter reporter)
   {
+    Objects.requireNonNull(reporter, "need to provide a reporter");
     this.reporter = reporter;
   }
   private Options(Scrubber scrubber, ApprovalFailureReporter reporter, FileOptions fileOptions)
@@ -38,10 +42,12 @@ public class Options
   }
   public Options withReporter(ApprovalFailureReporter reporter)
   {
+    Objects.requireNonNull(reporter, "need to provide a reporter");
     return new Options(this.scrubber, reporter, fileOptions);
   }
   public Options withScrubber(Scrubber scrubber)
   {
+    Objects.requireNonNull(scrubber, "need to provide a scrubber");
     return new Options(scrubber, this.reporter, fileOptions);
   }
   public String scrub(String input)


### PR DESCRIPTION
I'd avoid using Optional as an argument.

Also added null checks for the arguments.