### PR TITLE
feat: add option to auto approval in FileApprover

### DIFF
--- a/approvaltests-tests/src/test/java/org/approvaltests/approvers/FileApproverTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/approvers/FileApproverTest.java
@@ -67,7 +67,7 @@ public class FileApproverTest
     ApprovalTextWriter writer = new ApprovalTextWriter("Random: ", new Options());
     ApprovalNamer namer = Approvals.createApprovalNamer();
     Function2<File, File, VerifyResult> approveEverything = (r, a) -> VerifyResult.SUCCESS;
-    Approvals.verify(new FileApprover(writer, namer, approveEverything));
+    Approvals.verify(new FileApprover(writer, namer, approveEverything, false));
     // end-snippet
   }
 }

--- a/approvaltests/src/main/java/org/approvaltests/approvers/FileApprover.java
+++ b/approvaltests/src/main/java/org/approvaltests/approvers/FileApprover.java
@@ -19,21 +19,38 @@ public class FileApprover implements ApprovalApprover
   private File                                approved;
   private final ApprovalWriter                writer;
   private Function2<File, File, VerifyResult> approver;
+  private boolean                             autoApprove;
   public FileApprover(ApprovalWriter writer, ApprovalNamer namer)
   {
-    this(writer, namer, FileApprover::approveTextFile);
+    this(writer, namer, FileApprover::approveTextFile, false);
   }
-  public FileApprover(ApprovalWriter writer, ApprovalNamer namer, Function2<File, File, VerifyResult> approver)
+  public FileApprover(ApprovalWriter writer, ApprovalNamer namer, boolean autoApprove)
+  {
+    this(writer, namer, FileApprover::approveTextFile, autoApprove);
+  }
+  public FileApprover(ApprovalWriter writer, ApprovalNamer namer, Function2<File, File, VerifyResult> approver,
+      boolean autoApprove)
   {
     this.writer = writer;
     received = namer.getReceivedFile(writer.getFileExtensionWithDot());
     approved = namer.getApprovedFile(writer.getFileExtensionWithDot());
     this.approver = approver;
+    this.autoApprove = autoApprove;
   }
   public VerifyResult approve()
   {
-    received = writer.writeReceivedFile(received);
-    return approver.call(received, approved);
+    File result = null;
+    if (autoApprove)
+    {
+      approved = writer.writeReceivedFile(approved);
+      result = approved;
+    }
+    else
+    {
+      received = writer.writeReceivedFile(received);
+      result = received;
+    }
+    return approver.call(result, approved);
   }
   public void cleanUpAfterSuccess(ApprovalFailureReporter reporter)
   {


### PR DESCRIPTION
To me, it really takes time to approve every single file when my test cases grow. So I wanna do it automatically, then I will review it before added to my source control

## Description

Add option to auto approval in FileApprover

## The solution

Added field `autoApprove` to FileApprover, and modify `approve` method.

## Notation

I prefer lots of very small commits prefixed with [Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md)


