### PR TITLE
d add hint on avoiding locale dependent test failures

### DIFF
--- a/developer_notes.md
+++ b/developer_notes.md
@@ -17,6 +17,18 @@ If you see test failures and want to carry on anyway (Some tests are machine or 
 
 	mvn install -DskipTests
 
+To avoid locale dependent test failures, you may execute tests with the en_US locale. 
+This is one way to do it (in approvaltests-tests/pom.xml and approvaltests-util-tests/pom.xml):
+
+    <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M5</version>
+            <configuration>
+                <argLine>-Duser.language=en -Duser.region=US</argLine>
+            </configuration>
+    </plugin>
+
+
 If you have trouble with the "mrunit" package which is listed on Maven central but doesn't seem to download, install it locally with this command:
 
 	mvn install:install-file -Dfile=missing_jars/mrunit-0.9.0-incubating-hadoop1.jar -DgroupId=org.apache.mrunit -DartifactId=mrunit -Dversion=0.9.0-incubating -Dpackaging=jar


### PR DESCRIPTION
## Description

Some of ApprovalTests own integration tests fail on a non-en_US locale.

## The solution

Running Maven Surefire_plugin with explicit language and region should allow these tests to pass.



