### PR TITLE
B Make WithTimeZone thread safe

### DIFF
--- a/approvaltests-util-tests/src/test/resources/junit-platform.properties
+++ b/approvaltests-util-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default = concurrent

--- a/approvaltests/src/main/java/org/approvaltests/utils/WithTimeZone.java
+++ b/approvaltests/src/main/java/org/approvaltests/utils/WithTimeZone.java
@@ -1,10 +1,12 @@
 package org.approvaltests.utils;
 
 import java.util.TimeZone;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class WithTimeZone implements AutoCloseable
 {
-  private final TimeZone tz;
+  private static final ReentrantLock defaultTimeZoneLock = new ReentrantLock();
+  private final TimeZone             tz;
   public WithTimeZone()
   {
     this("UTC");
@@ -12,11 +14,13 @@ public class WithTimeZone implements AutoCloseable
   public WithTimeZone(String zoneId)
   {
     tz = TimeZone.getDefault();
+    defaultTimeZoneLock.lock();
     TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
   }
   @Override
   public void close()
   {
     TimeZone.setDefault(tz);
+    defaultTimeZoneLock.unlock();
   }
 }


### PR DESCRIPTION
## Description

Default time zone is global for a whole JVM instance, so a thread using `WithTimeZone` must be guaranteed that a concurrent thread does not change it in mid-execution.

## The solution

Place a lock on entering the critical section which sets the default time zone, and release it on close.
This change makes the approvaltests-util-tests suite pass even when it is run with `junit.jupiter.execution.parallel.mode.default = concurrent` (See  #181).




