### PR TITLE
B Make NamerFactory and TestUtils thread safe

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/namer/NamedEnvironment.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/NamedEnvironment.java
@@ -8,7 +8,7 @@ public class NamedEnvironment implements AutoCloseable
 {
   public NamedEnvironment(String info)
   {
-    NamerFactory.additionalInformation = info;
+    NamerFactory.setAdditionalInformation(info);
   }
   @Override
   public void close()
@@ -17,14 +17,14 @@ public class NamedEnvironment implements AutoCloseable
   }
   public boolean isCurrentEnvironmentValidFor(String... environment)
   {
-    if (Arrays.asList(environment).contains(NamerFactory.additionalInformation))
+    if (Arrays.asList(environment).contains(NamerFactory.getAdditionalInformation()))
     {
       return true;
     }
     else
     {
-      SimpleLogger
-          .message(String.format("Not valid for current environment: \"%s\"", NamerFactory.additionalInformation));
+      SimpleLogger.message(
+          String.format("Not valid for current environment: \"%s\"", NamerFactory.getAdditionalInformation()));
       return false;
     }
   }

--- a/approvaltests/src/main/java/org/approvaltests/namer/NamerFactory.java
+++ b/approvaltests/src/main/java/org/approvaltests/namer/NamerFactory.java
@@ -9,18 +9,18 @@ import com.spun.util.SystemUtils;
 
 public class NamerFactory
 {
-  public static String additionalInformation;
+  private static final ThreadLocal<String> additionalInformation = new ThreadLocal<>();
   public static String getAndClearAdditionalInformation()
   {
     String result = getAdditionalInformation();
-    additionalInformation = null;
+    additionalInformation.set(null);
     return result;
   }
   public static String getAdditionalInformation()
   {
-    if (additionalInformation == null)
+    if (additionalInformation.get() == null)
     { return ""; }
-    return "." + additionalInformation;
+    return "." + additionalInformation.get();
   }
   public static ApprovalResults ApprovalResults = new ApprovalResults();
   public static NamedEnvironment asMachineSpecificTest(Function0<String> environmentLabeller)
@@ -57,6 +57,10 @@ public class NamerFactory
   }
   public static boolean isEmpty()
   {
-    return additionalInformation == null;
+    return additionalInformation.get() == null;
+  }
+  public static void setAdditionalInformation(String info)
+  {
+    additionalInformation.set(info);
   }
 }

--- a/approvaltests/src/test/resources/junit-platform.properties
+++ b/approvaltests/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
## Description

`NamerFactory` uses the global variable `additionalInformation` to attach additional naming information to the current test run. The test initializes the variable, and uses it in a future time, so the value must remain constant for the duration of the test. This causes a race condition when tests are run concurrently.

The same happens with the variable `getSourceDirectory` in `TestUtils`.

## The solution

While a lock may be used, probably a better solution is to give each thread its own copy of the variable, to prevent race conditions.
