### PR TITLE
Support for TortoiseGIT added

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/reporters/DiffPrograms.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/DiffPrograms.java
@@ -43,6 +43,10 @@ public class DiffPrograms
         "/left:%s /right:%s", IMAGE);
     public static DiffInfo TORTOISE_TEXT_DIFF  = new DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseMerge.exe",
         TEXT);
+    public static DiffInfo TORTOISE_GIT_IMAGE_DIFF = new DiffInfo("{ProgramFiles}TortoiseGIT\\bin\\TortoiseIDiff.exe",
+    		"/left:%s /right:%s", IMAGE);
+    public static DiffInfo TORTOISE_GIT_TEXT_DIFF  = new DiffInfo("{ProgramFiles}TortoiseGIT\\bin\\TortoiseMerge.exe",
+    		TEXT);
     public static DiffInfo WIN_MERGE_REPORTER  = new DiffInfo("{ProgramFiles}WinMerge\\WinMergeU.exe",
         TEXT_AND_IMAGE);
     public static DiffInfo ARAXIS_MERGE        = new DiffInfo("{ProgramFiles}Araxis\\Araxis Merge\\Compare.exe",

--- a/approvaltests/src/main/java/org/approvaltests/reporters/DiffPrograms.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/DiffPrograms.java
@@ -43,9 +43,9 @@ public class DiffPrograms
         "/left:%s /right:%s", IMAGE);
     public static DiffInfo TORTOISE_TEXT_DIFF  = new DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseMerge.exe",
         TEXT);
-    public static DiffInfo TORTOISE_GIT_IMAGE_DIFF = new DiffInfo("{ProgramFiles}TortoiseGIT\\bin\\TortoiseIDiff.exe",
+    public static DiffInfo TORTOISE_GIT_IMAGE_DIFF = new DiffInfo("{ProgramFiles}TortoiseGIT\\bin\\TortoiseGitIDiff.exe",
     		"/left:%s /right:%s", IMAGE);
-    public static DiffInfo TORTOISE_GIT_TEXT_DIFF  = new DiffInfo("{ProgramFiles}TortoiseGIT\\bin\\TortoiseMerge.exe",
+    public static DiffInfo TORTOISE_GIT_TEXT_DIFF  = new DiffInfo("{ProgramFiles}TortoiseGIT\\bin\\TortoiseGitMerge.exe",
     		TEXT);
     public static DiffInfo WIN_MERGE_REPORTER  = new DiffInfo("{ProgramFiles}WinMerge\\WinMergeU.exe",
         TEXT_AND_IMAGE);

--- a/approvaltests/src/main/java/org/approvaltests/reporters/ImageReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/ImageReporter.java
@@ -2,13 +2,14 @@ package org.approvaltests.reporters;
 
 import org.approvaltests.reporters.macosx.KaleidoscopeDiffReporter;
 import org.approvaltests.reporters.windows.BeyondCompareReporter;
+import org.approvaltests.reporters.windows.TortoiseGitImageDiffReporter;
 import org.approvaltests.reporters.windows.TortoiseImageDiffReporter;
 
 public class ImageReporter extends FirstWorkingReporter
 {
   public ImageReporter()
   {
-    super(TortoiseImageDiffReporter.INSTANCE, BeyondCompareReporter.INSTANCE, KaleidoscopeDiffReporter.INSTANCE,
-        ImageWebReporter.INSTANCE, QuietReporter.INSTANCE);
+    super(TortoiseImageDiffReporter.INSTANCE, TortoiseGitImageDiffReporter.INSTANCE, BeyondCompareReporter.INSTANCE, 
+    	    KaleidoscopeDiffReporter.INSTANCE, ImageWebReporter.INSTANCE, QuietReporter.INSTANCE);
   }
 }

--- a/approvaltests/src/main/java/org/approvaltests/reporters/windows/TortoiseDiffReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/windows/TortoiseDiffReporter.java
@@ -7,6 +7,7 @@ public class TortoiseDiffReporter extends FirstWorkingReporter
   public static final TortoiseDiffReporter INSTANCE = new TortoiseDiffReporter();
   public TortoiseDiffReporter()
   {
-    super(TortoiseTextDiffReporter.INSTANCE, TortoiseImageDiffReporter.INSTANCE);
+    super(TortoiseTextDiffReporter.INSTANCE, TortoiseImageDiffReporter.INSTANCE,
+        TortoiseGitTextDiffReporter.INSTANCE, TortoiseGitImageDiffReporter.INSTANCE);
   }
 }

--- a/approvaltests/src/main/java/org/approvaltests/reporters/windows/TortoiseGitImageDiffReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/windows/TortoiseGitImageDiffReporter.java
@@ -1,0 +1,13 @@
+package org.approvaltests.reporters.windows;
+
+import org.approvaltests.reporters.DiffPrograms.Windows;
+import org.approvaltests.reporters.GenericDiffReporter;
+
+public class TortoiseGitImageDiffReporter extends GenericDiffReporter
+{
+  public static final TortoiseGitImageDiffReporter INSTANCE = new TortoiseGitImageDiffReporter();
+  public TortoiseGitImageDiffReporter()
+  {
+    super(Windows.TORTOISE_GIT_IMAGE_DIFF);
+  }
+}

--- a/approvaltests/src/main/java/org/approvaltests/reporters/windows/TortoiseGitTextDiffReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/windows/TortoiseGitTextDiffReporter.java
@@ -1,0 +1,13 @@
+package org.approvaltests.reporters.windows;
+
+import org.approvaltests.reporters.DiffPrograms.Windows;
+import org.approvaltests.reporters.GenericDiffReporter;
+
+public class TortoiseGitTextDiffReporter extends GenericDiffReporter
+{
+  public static final TortoiseGitTextDiffReporter INSTANCE = new TortoiseGitTextDiffReporter();
+  public TortoiseGitTextDiffReporter()
+  {
+    super(Windows.TORTOISE_GIT_TEXT_DIFF);
+  }
+}


### PR DESCRIPTION

## Description
Approvals comes with support for TortoiseSVN. Since path and binary names of TortoiseGIT differs I added support for TortoiseGIT. 

## The solution

Classes and paths for TortoiseGIT reporters added. I didn't check what tools are supported in the python/.net/cpp/ruby/node/... version of Approvals. If TortoiseSVN is supported there but TortoiseGIT not, support should be added there as well if Approval's tool support for different languages should be consistent.  

## Notation

Could you please squash those commit to `F!! Support for TortoiseGIT added`
