### PR TITLE
Extend list of known text file extensions

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/reporters/GenericDiffReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/GenericDiffReporter.java
@@ -22,7 +22,7 @@ public class GenericDiffReporter implements ApprovalFailureReporter
   protected String           diffProgramNotFoundMessage;
   private List<String>       validExtensions;
   public static List<String> TEXT_FILE_EXTENSIONS  = Arrays.asList(".txt", ".csv", ".htm", ".html", ".xml", ".eml",
-      ".java", ".css", ".js", ".json", ".md");
+      ".java", ".css", ".js", ".json", ".md", ".jsonl", ".yaml", ".yml", ".adoc", ".asciidoc");
   public static List<String> IMAGE_FILE_EXTENSIONS = Arrays.asList(".png", ".gif", ".jpg", ".jpeg", ".bmp", ".tif",
       ".tiff");
   public GenericDiffReporter(String diffProgram)


### PR DESCRIPTION
## Description
Adds built-in support for additional known text file formats which will be opened with diff tools:
- JSON Lines
- YAML
- Asciidoc

## Solutio
Added entries to the existing default list in the TEXT_FILE_EXTENSIONS constant of `GenericDiffReporter`.

A long term solution should allow this list to be configured without having to cut a new release nor having to manually create a reporter.


