### PR TITLE
F!! Add auto approve reporter based on system properties

### DIFF
--- a/approvaltests-tests/src/test/java/org/approvaltests/reporters/AutoApproveWhenPropertySetReporterTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/reporters/AutoApproveWhenPropertySetReporterTest.java
@@ -1,0 +1,50 @@
+package org.approvaltests.reporters;
+
+import com.spun.util.io.FileUtils;
+import org.approvaltests.Approvals;
+import org.approvaltests.core.Options;
+import org.approvaltests.namer.NamerWrapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AutoApproveWhenPropertySetReporterTest
+{
+  @Test
+  void testWhenPropertyIsSet()
+  {
+    NamerWrapper namer = new NamerWrapper(Approvals.createApprovalNamer());
+    cleanupFiles(namer);
+    System.setProperty("org.approvaltests.reporters.autoapprove", "true");
+    Approvals.verify("applesauce", new Options().withReporter(new AutoApproveWhenPropertySetReporter()));
+    assertTrue(namer.getApprovalFile(".txt").exists());
+    assertFalse(namer.getReceivedFile((".txt")).exists());
+    cleanupFiles(namer);
+  }
+  @Test
+  void testWhenPropertyNotSet()
+  {
+    System.clearProperty("org.approvaltests.reporters.autoapprove");
+    NamerWrapper namer = new NamerWrapper(Approvals.createApprovalNamer());
+    cleanupFiles(namer);
+    try
+    {
+      Approvals.verify("applesauce",
+          new Options().withReporter(new AutoApproveWhenPropertySetReporter(new UseReporterTest.TestReporter(),
+              "org.approvaltests.reporters.autoapprove")));
+    }
+    catch (Throwable t)
+    {
+      assertTrue(t.getMessage().startsWith("Failed Approval"));
+    }
+    assertFalse(namer.getApprovalFile(".txt").exists());
+    assertTrue(namer.getReceivedFile(".txt").exists());
+    cleanupFiles(namer);
+  }
+  private static void cleanupFiles(NamerWrapper namer)
+  {
+    FileUtils.delete(namer.getApprovalFile(".txt"));
+    FileUtils.delete(namer.getReceivedFile((".txt")));
+  }
+}

--- a/approvaltests/src/main/java/org/approvaltests/reporters/AutoApproveWhenPropertySetReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/reporters/AutoApproveWhenPropertySetReporter.java
@@ -1,0 +1,45 @@
+package org.approvaltests.reporters;
+
+import com.spun.util.io.FileUtils;
+import org.approvaltests.Approvals;
+import org.approvaltests.core.ApprovalFailureReporter;
+import org.approvaltests.core.VerifyResult;
+
+import java.io.File;
+
+public class AutoApproveWhenPropertySetReporter implements ReporterWithApprovalPower
+{
+  private final ApprovalFailureReporter reporter;
+  private final String                  property;
+  private VerifyResult                  result;
+  public AutoApproveWhenPropertySetReporter()
+  {
+    this(Approvals.getReporter(), "org.approvaltests.reporters.autoapprove");
+  }
+  public AutoApproveWhenPropertySetReporter(ApprovalFailureReporter reporter, String property)
+  {
+    this.reporter = reporter;
+    this.property = property;
+  }
+  @Override
+  public boolean report(String received, String approved)
+  {
+    String v = System.getProperty(property);
+    if ("".equals(v) || "true".equalsIgnoreCase(v))
+    {
+      FileUtils.copyFile(new File(received), new File(approved));
+      result = VerifyResult.SUCCESS;
+    }
+    else
+    {
+      reporter.report(received, approved);
+      result = VerifyResult.FAILURE;
+    }
+    return true;
+  }
+  @Override
+  public VerifyResult approveWhenReported()
+  {
+    return result;
+  }
+}


### PR DESCRIPTION
## Description

The new reporter will automatically approve the changeset (copy received to approved) when a specified System property is set (to true or it is simply present).

The goal is to allow to update easily all relevant files from the tests that are run, without requiring code changes but in a controlled manner (only when the user explicitly sets the property).

The new auto approver would be very useful for projects using `maven`, `gradle`, etc, where system properties can be passed along when running a test. For instance:

```
mvn test -Dtest=TestMySuperExampleUsingApproval -Dorg.approvaltests.reporters.autoapprove (triggers the auto approver and creates/updates the .aproved files)
mvn test -Dtest=TestMySuperExampleUsingApproval (doesn't trigger the auto approver and if files do not match it simply fails)
```
