### PR TITLE
D Fixing CI Icons on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-[![Build Status](https://github.com/approvals/ApprovalTests.java/workflows/mvn%20verify%20linux/badge.svg?branch=master)](https://github.com/approvals/ApprovalTests.java/actions?query=build%3Amaster) 
-[![Build Status](https://github.com/approvals/ApprovalTests.java/workflows/mvn%20verify%20windows/badge.svg?branch=master)](https://github.com/approvals/ApprovalTests.java/actions?query=build%3Amaster)
+[![FormatJava](https://github.com/approvals/ApprovalTests.Java/actions/workflows/formatJava.yml/badge.svg)](https://github.com/approvals/ApprovalTests.Java/actions/workflows/formatJava.yml)
+[![Run tests](https://github.com/approvals/ApprovalTests.Java/actions/workflows/test.yml/badge.svg)](https://github.com/approvals/ApprovalTests.Java/actions/workflows/test.yml)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.approvaltests/approvaltests/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.approvaltests/approvaltests)
 <!-- toc -->
 ## Contents


### PR DESCRIPTION
## Description

Current CI status icons are broken in the readme.
![image](https://github.com/approvals/ApprovalTests.Java/assets/7319391/2552c02c-fc0d-45ca-9b86-97d1c241e94d)

## The solution

I replaced them with valid ones.

![image](https://github.com/approvals/ApprovalTests.Java/assets/7319391/a56e1581-3130-4db2-b305-409112141231)


