### PR TITLE
e - Added tests to show discrepancies when handling XML output by Jackson.

### DIFF
--- a/approvaltests-tests/pom.xml
+++ b/approvaltests-tests/pom.xml
@@ -105,6 +105,11 @@
             <version>2.16.1</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-xstream</artifactId>
             <version>3.22.0</version>

--- a/approvaltests-tests/src/test/java/org/approvaltests/Parse1InputTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/Parse1InputTest.java
@@ -22,6 +22,7 @@ public class Parse1InputTest
         """;
     ParseInput.from(expected).withTypes(Integer.class).verifyAll(Integer::toBinaryString);
     ParseInput.from(expected).transformTo(Integer::parseInt).verifyAll(Integer::toBinaryString);
-    ParseInput.from(expected).withTypes(String.class).transformTo(Integer::parseInt).verifyAll(Integer::toBinaryString);
+    ParseInput.from(expected).withTypes(String.class).transformTo(Integer::parseInt)
+        .verifyAll(Integer::toBinaryString);
   }
 }

--- a/approvaltests-tests/src/test/java/org/approvaltests/Parse2InputTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/Parse2InputTest.java
@@ -8,12 +8,12 @@ public class Parse2InputTest
   void testWithTypesTransformersAndBoth()
   {
     var expected = """
-      1,2.2 -> 2.2
-      1,3.3 -> 3.3
-      """;
+        1,2.2 -> 2.2
+        1,3.3 -> 3.3
+        """;
     ParseInput.from(expected).withTypes(Integer.class, Double.class).verifyAll(t -> t.getFirst() * t.getSecond());
     // TODO: continue here
-//    ParseInput.from(expected).transformTo(Integer::parseInt).verifyAll(Integer::toBinaryString);
-//    ParseInput.from(expected).withTypes(String.class).transformTo(Integer::parseInt).verifyAll(Integer::toBinaryString);
+    //    ParseInput.from(expected).transformTo(Integer::parseInt).verifyAll(Integer::toBinaryString);
+    //    ParseInput.from(expected).withTypes(String.class).transformTo(Integer::parseInt).verifyAll(Integer::toBinaryString);
   }
 }

--- a/approvaltests-tests/src/test/java/org/approvaltests/writers/ApprovalXmlWriterTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/writers/ApprovalXmlWriterTest.java
@@ -11,72 +11,67 @@ import org.junit.jupiter.api.Test;
 
 import static com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator.Feature.WRITE_XML_DECLARATION;
 
-public class ApprovalXmlWriterTest {
-    @Test
-    public void plainXml() {
-        Approvals.verifyXml("<xml><hello/><start>hi</start></xml>");
+public class ApprovalXmlWriterTest
+{
+  @Test
+  public void plainXml()
+  {
+    Approvals.verifyXml("<xml><hello/><start>hi</start></xml>");
+  }
+  @Test
+  public void xmlWithAttributes()
+  {
+    Approvals.verifyXml("<xml b=\"123\" a=\"456\"><hello x=\"y\"/><start>hi</start></xml>");
+  }
+  @Test
+  public void xmlWithDeepAttributes()
+  {
+    Approvals
+        .verifyXml("<xml b=\"1\" a=\"1\"><branch1 b=\"1\" a=\"1\"/><branch2 b=\"1\" a=\"1\">hi</branch2></xml>");
+  }
+  @Test
+  public void xmlWithDeepAttributesWithScrubber()
+  {
+    Approvals.verifyXml(
+        "<xml b=\"1\" a=\"1\"><branch1 b=\"1\" a=\"1\"/><branch2 b=\"1\" a=\"1\">hi</branch2></xml>",
+        new Options(new RegExScrubber("hi", "hello")));
+  }
+  @Test
+  public void invalidXml()
+  {
+    Approvals.verifyXml("<xml><hello/><start>hi</xml>");
+    System.err.println("Note: The previous xml error (</start>) is expected ");
+  }
+  @Test
+  void xmlOutputByJacksonIsHandledCorrectly() throws JsonProcessingException
+  {
+    ObjectWriter objectWriter = new XmlMapper().configure(WRITE_XML_DECLARATION, true).writer();
+    String jacksonXml = objectWriter.writeValueAsString(new JacksonTestPOJO());
+    String approvalsWriterXml = ApprovalXmlWriter.prettyPrint(jacksonXml, 2);
+    Assertions.assertEquals(jacksonXml, approvalsWriterXml);
+  }
+  @Test
+  void xmlOutputByJacksonIsHandledCorrectlyWhenPrettyPrintingIsEnabled() throws JsonProcessingException
+  {
+    ObjectWriter objectWriter = new XmlMapper().configure(WRITE_XML_DECLARATION, true)
+        .writerWithDefaultPrettyPrinter();
+    String jacksonXml = objectWriter.writeValueAsString(new JacksonTestPOJO());
+    String approvalsWriterXml = ApprovalXmlWriter.prettyPrint(jacksonXml, 2);
+    Assertions.assertEquals(jacksonXml, approvalsWriterXml);
+  }
+  private static class JacksonTestPOJO
+  {
+    public String getSomeText()
+    {
+      return "Some text";
     }
-
-    @Test
-    public void xmlWithAttributes() {
-        Approvals.verifyXml("<xml b=\"123\" a=\"456\"><hello x=\"y\"/><start>hi</start></xml>");
+    public String getSomeTextWithAmpersand()
+    {
+      return "Some more text & some more";
     }
-
-    @Test
-    public void xmlWithDeepAttributes() {
-        Approvals
-                .verifyXml("<xml b=\"1\" a=\"1\"><branch1 b=\"1\" a=\"1\"/><branch2 b=\"1\" a=\"1\">hi</branch2></xml>");
+    public String getEmoji()
+    {
+      return "😸";
     }
-
-    @Test
-    public void xmlWithDeepAttributesWithScrubber() {
-        Approvals.verifyXml(
-                "<xml b=\"1\" a=\"1\"><branch1 b=\"1\" a=\"1\"/><branch2 b=\"1\" a=\"1\">hi</branch2></xml>",
-                new Options(new RegExScrubber("hi", "hello")));
-    }
-
-    @Test
-    public void invalidXml() {
-        Approvals.verifyXml("<xml><hello/><start>hi</xml>");
-        System.err.println("Note: The previous xml error (</start>) is expected ");
-    }
-
-    @Test
-    void xmlOutputByJacksonIsHandledCorrectly() throws JsonProcessingException {
-        ObjectWriter objectWriter = new XmlMapper()
-                .configure(WRITE_XML_DECLARATION, true)
-                .writer();
-
-        String jacksonXml = objectWriter.writeValueAsString(new JacksonTestPOJO());
-        String approvalsWriterXml = ApprovalXmlWriter.prettyPrint(jacksonXml, 2);
-
-        Assertions.assertEquals(jacksonXml, approvalsWriterXml);
-    }
-
-    @Test
-    void xmlOutputByJacksonIsHandledCorrectlyWhenPrettyPrintingIsEnabled() throws JsonProcessingException {
-        ObjectWriter objectWriter = new XmlMapper()
-                .configure(WRITE_XML_DECLARATION, true)
-                .writerWithDefaultPrettyPrinter();
-
-        String jacksonXml = objectWriter.writeValueAsString(new JacksonTestPOJO());
-        String approvalsWriterXml = ApprovalXmlWriter.prettyPrint(jacksonXml, 2);
-
-        Assertions.assertEquals(jacksonXml, approvalsWriterXml);
-    }
-
-    private static class JacksonTestPOJO {
-
-        public String getSomeText() {
-            return "Some text";
-        }
-
-        public String getSomeTextWithAmpersand() {
-            return "Some more text & some more";
-        }
-
-        public String getEmoji() {
-            return "😸";
-        }
-    }
+  }
 }

--- a/approvaltests-tests/src/test/java/org/approvaltests/writers/ApprovalXmlWriterTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/writers/ApprovalXmlWriterTest.java
@@ -1,39 +1,82 @@
 package org.approvaltests.writers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.approvaltests.Approvals;
 import org.approvaltests.core.Options;
 import org.approvaltests.scrubbers.RegExScrubber;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ApprovalXmlWriterTest
-{
-  @Test
-  public void plainXml()
-  {
-    Approvals.verifyXml("<xml><hello/><start>hi</start></xml>");
-  }
-  @Test
-  public void xmlWithAttributes()
-  {
-    Approvals.verifyXml("<xml b=\"123\" a=\"456\"><hello x=\"y\"/><start>hi</start></xml>");
-  }
-  @Test
-  public void xmlWithDeepAttributes()
-  {
-    Approvals
-        .verifyXml("<xml b=\"1\" a=\"1\"><branch1 b=\"1\" a=\"1\"/><branch2 b=\"1\" a=\"1\">hi</branch2></xml>");
-  }
-  @Test
-  public void xmlWithDeepAttributesWithScrubber()
-  {
-    Approvals.verifyXml(
-        "<xml b=\"1\" a=\"1\"><branch1 b=\"1\" a=\"1\"/><branch2 b=\"1\" a=\"1\">hi</branch2></xml>",
-        new Options(new RegExScrubber("hi", "hello")));
-  }
-  @Test
-  public void invalidXml()
-  {
-    Approvals.verifyXml("<xml><hello/><start>hi</xml>");
-    System.err.println("Note: The previous xml error (</start>) is expected ");
-  }
+import static com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator.Feature.WRITE_XML_DECLARATION;
+
+public class ApprovalXmlWriterTest {
+    @Test
+    public void plainXml() {
+        Approvals.verifyXml("<xml><hello/><start>hi</start></xml>");
+    }
+
+    @Test
+    public void xmlWithAttributes() {
+        Approvals.verifyXml("<xml b=\"123\" a=\"456\"><hello x=\"y\"/><start>hi</start></xml>");
+    }
+
+    @Test
+    public void xmlWithDeepAttributes() {
+        Approvals
+                .verifyXml("<xml b=\"1\" a=\"1\"><branch1 b=\"1\" a=\"1\"/><branch2 b=\"1\" a=\"1\">hi</branch2></xml>");
+    }
+
+    @Test
+    public void xmlWithDeepAttributesWithScrubber() {
+        Approvals.verifyXml(
+                "<xml b=\"1\" a=\"1\"><branch1 b=\"1\" a=\"1\"/><branch2 b=\"1\" a=\"1\">hi</branch2></xml>",
+                new Options(new RegExScrubber("hi", "hello")));
+    }
+
+    @Test
+    public void invalidXml() {
+        Approvals.verifyXml("<xml><hello/><start>hi</xml>");
+        System.err.println("Note: The previous xml error (</start>) is expected ");
+    }
+
+    @Test
+    void xmlOutputByJacksonIsHandledCorrectly() throws JsonProcessingException {
+        ObjectWriter objectWriter = new XmlMapper()
+                .configure(WRITE_XML_DECLARATION, true)
+                .writer();
+
+        String jacksonXml = objectWriter.writeValueAsString(new JacksonTestPOJO());
+        String approvalsWriterXml = ApprovalXmlWriter.prettyPrint(jacksonXml, 2);
+
+        Assertions.assertEquals(jacksonXml, approvalsWriterXml);
+    }
+
+    @Test
+    void xmlOutputByJacksonIsHandledCorrectlyWhenPrettyPrintingIsEnabled() throws JsonProcessingException {
+        ObjectWriter objectWriter = new XmlMapper()
+                .configure(WRITE_XML_DECLARATION, true)
+                .writerWithDefaultPrettyPrinter();
+
+        String jacksonXml = objectWriter.writeValueAsString(new JacksonTestPOJO());
+        String approvalsWriterXml = ApprovalXmlWriter.prettyPrint(jacksonXml, 2);
+
+        Assertions.assertEquals(jacksonXml, approvalsWriterXml);
+    }
+
+    private static class JacksonTestPOJO {
+
+        public String getSomeText() {
+            return "Some text";
+        }
+
+        public String getSomeTextWithAmpersand() {
+            return "Some more text & some more";
+        }
+
+        public String getEmoji() {
+            return "😸";
+        }
+    }
 }


### PR DESCRIPTION
Added tests to show discrepancies between XML generated by Jackson and that output by `ApprovalXmlWriter.prettyPrint()`.