### PR TITLE
d Maven dependency should be test scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If you're using Maven, add this to your pom file:
     <groupId>com.approvaltests</groupId>
     <artifactId>approvaltests</artifactId>
     <version>22.4.0</version>
+    <scope>test</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
In normal usage, `approvaltests` is only used for testing, so the Maven dependency example should specify "test" scope. `approvaltests` is not normally needed by the code itself, just by the test code.

This is the equivalent to the `testImplementation` specified in the Gradle example.