### PR TITLE
Throw AssertionError instead of Error in case of approval failure

### DIFF
--- a/approvaltests/src/main/java/org/approvaltests/Approvals.java
+++ b/approvaltests/src/main/java/org/approvaltests/Approvals.java
@@ -321,7 +321,7 @@ public class Approvals
     if (!mismatched.isEmpty())
     {
       String message = "The Following Files did not match up: " + getFileNameList(mismatched);
-      throw new Error(message);
+      throw new AssertionError(message);
     }
   }
   private static String getFileNameList(List<File> mismatched)

--- a/approvaltests/src/main/java/org/approvaltests/approvers/FileApprover.java
+++ b/approvaltests/src/main/java/org/approvaltests/approvers/FileApprover.java
@@ -58,7 +58,7 @@ public class FileApprover implements ApprovalApprover
   }
   public void fail()
   {
-    throw new Error(String.format("Failed Approval\n  Approved:%s\n  Received:%s", approved.getAbsolutePath(),
+    throw new AssertionError(String.format("Failed Approval\n  Approved:%s\n  Received:%s", approved.getAbsolutePath(),
         received.getAbsolutePath()));
   }
   public static VerifyResult approveTextFile(File received, File approved)


### PR DESCRIPTION
Approval failures currently throw Error, but should throw AssertionError to actually distinguish functional failure (AssertionError) from technical failure (everything else).

## Summary by Sourcery

Bug Fixes:
- Throw AssertionError instead of Error in case of approval failure to distinguish functional failures from technical failures.