### PR TITLE
. r remove testng

### DIFF
--- a/approvaltests/pom.xml
+++ b/approvaltests/pom.xml
@@ -26,12 +26,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>7.10.2</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <version>1.4.21</version>


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove org.testng:testng dependency from approvaltests pom.xml