### PR TITLE
. B fix inline approvals for JUnit 5 @Nested classes

### DIFF
--- a/approvaltests-tests/src/test/java/org/approvaltests/inline/InlineApprovalsTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/inline/InlineApprovalsTest.java
@@ -7,6 +7,7 @@ import org.approvaltests.reporters.DiffMergeReporter;
 import org.approvaltests.reporters.FirstWorkingReporter;
 import org.approvaltests.reporters.QuietReporter;
 import org.approvaltests.reporters.UseReporter;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.lambda.actions.Action1;
 import org.lambda.utils.Mutable;
@@ -217,4 +218,18 @@ public class InlineApprovalsTest
     Approvals.verify(expected);
   }
   // @formatter:on
+  @Nested
+  class NestedTest
+  {
+    @Test
+    void testInlineFromInnerClass()
+    {
+      var expected = """
+          hello Oskar
+          """;
+      Options options = new Options().inline("", InlineOptions.automatic());
+      Mutable<String> result = hijackInlineReporter(options);
+      assertApprovalFailure("hello Oskar", options, e -> assertEquals(expected, result.get()));
+    }
+  }
 }

--- a/approvaltests-util/src/main/java/com/spun/util/tests/StackTraceReflectionResult.java
+++ b/approvaltests-util/src/main/java/com/spun/util/tests/StackTraceReflectionResult.java
@@ -5,12 +5,15 @@ import java.io.File;
 public class StackTraceReflectionResult
 {
   private final File   sourceFile;
+  private final String fileName;
   private final String className;
   private final String methodName;
-  private String       fullClassName;
-  public StackTraceReflectionResult(File sourceFile, String className, String fullClassName, String methodName)
+  private final String fullClassName;
+  public StackTraceReflectionResult(File sourceFile, String fileName, String className, String fullClassName,
+      String methodName)
   {
     this.sourceFile = sourceFile;
+    this.fileName = fileName;
     this.className = className;
     this.fullClassName = fullClassName;
     this.methodName = methodName;
@@ -18,6 +21,10 @@ public class StackTraceReflectionResult
   public File getSourceFile()
   {
     return sourceFile;
+  }
+  public String getFileName()
+  {
+    return fileName;
   }
   public String getClassName()
   {

--- a/approvaltests-util/src/main/java/com/spun/util/tests/TestUtils.java
+++ b/approvaltests-util/src/main/java/com/spun/util/tests/TestUtils.java
@@ -194,7 +194,7 @@ public class TestUtils
     String fileName = element.getFileName();
     File dir = getSourceDirectory.get().call(ObjectUtils.loadClass(fullClassName), fileName);
     String methodName = unrollLambda(element.getMethodName());
-    return new StackTraceReflectionResult(dir, className, fullClassName, methodName);
+    return new StackTraceReflectionResult(dir, fileName, className, fullClassName, methodName);
   }
   private static String handleInnerClasses(String className)
   {

--- a/approvaltests/src/main/java/org/approvaltests/inline/InlineJavaReporter.java
+++ b/approvaltests/src/main/java/org/approvaltests/inline/InlineJavaReporter.java
@@ -38,13 +38,13 @@ public class InlineJavaReporter implements ApprovalFailureReporter, ApprovalRepo
   public boolean report(String received, String approved)
   {
     additionalLines = footerCreator.call(received, approved);
-    String sourceFile = sourceFilePath + stackTraceNamer.getInfo().getClassName() + ".java";
+    String sourceFile = sourceFilePath + stackTraceNamer.getInfo().getFileName();
     String newSource = createReceived(FileUtils.readFile(received));
     return reporter.report(newSource, sourceFile);
   }
   public String createReceived(String actual)
   {
-    String file = sourceFilePath + stackTraceNamer.getInfo().getClassName() + ".java";
+    String file = sourceFilePath + stackTraceNamer.getInfo().getFileName();
     String received = getReceivedFileName();
     String text = FileUtils.readFile(file);
     String fullText = this.createNewReceivedFileText.call(text, actual + additionalLines,


### PR DESCRIPTION
## Description

The inline approvals feature now correctly handles @Nested inner test classes. 

Previously, InlineJavaReporter would fail when trying to resolve the source file for nested classes, attempting to open non-existent files like`OuterClass.InnerClass.java`.

Fixes #699 

## The solution

- Store original filename from stack trace in StackTraceReflectionResult
- Use original filename instead of reconstructing from class name
- Add test case for @Nested class inline approvals

## Summary by Sourcery

Enable inline approvals to resolve source files for nested JUnit 5 test classes by preserving the original filename from the stack trace and using it instead of reconstructing from the class name

Bug Fixes:
- Fix inline approval reporter to correctly locate source files for @Nested inner classes

Enhancements:
- Store the original file name in StackTraceReflectionResult
- Use the preserved file name in InlineJavaReporter for generating source paths

Tests:
- Add a JUnit 5 @Nested test case to verify inline approvals in inner classes