### PR TITLE
add support of Jackson 3

### DIFF
--- a/approvaltests-tests/pom.xml
+++ b/approvaltests-tests/pom.xml
@@ -15,6 +15,18 @@
         <kotlin.version>2.2.21</kotlin.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>3.0.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -125,6 +137,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.20.1</version>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/approvaltests-tests/src/test/java/org/approvaltests/JsonJackson3ApprovalsTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/JsonJackson3ApprovalsTest.java
@@ -1,0 +1,54 @@
+package org.approvaltests;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.junit.jupiter.api.Test;
+
+class JsonJackson3ApprovalsTest
+{
+  @Test
+  void testObjectMapperOverride()
+  {
+    MyClass o = new MyClass();
+    JsonJackson3Approvals.verifyAsJson(o,
+        jm -> jm.changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL)));
+  }
+
+  @Test
+  void testDuplicateFields()
+  {
+    JsonJackson3Approvals.verifyAsJson(new MyOtherClass());
+  }
+  private static class MyClass
+  {
+    @JsonIgnore
+    private String name       = "MyClass";
+    public String  lastName   = "MyClass";
+    public String  middleName = null;
+    public String getName()
+    {
+      return name;
+    }
+
+    public void setName(String name)
+    {
+      this.name = name;
+    }
+  }
+  private static class MyOtherClass extends MyClass
+  {
+    @JsonIgnore
+    private String name = "MyOtherClass";
+    @Override
+    public String getName()
+    {
+      return name;
+    }
+
+    @Override
+    public void setName(String name)
+    {
+      this.name = name;
+    }
+  }
+}

--- a/approvaltests-tests/src/test/java/org/approvaltests/JsonJackson3ApprovalsTest.testDuplicateFields.approved.json
+++ b/approvaltests-tests/src/test/java/org/approvaltests/JsonJackson3ApprovalsTest.testDuplicateFields.approved.json
@@ -1,0 +1,4 @@
+{
+  "lastName" : "MyClass",
+  "middleName" : null
+}

--- a/approvaltests-tests/src/test/java/org/approvaltests/JsonJackson3ApprovalsTest.testObjectMapperOverride.approved.json
+++ b/approvaltests-tests/src/test/java/org/approvaltests/JsonJackson3ApprovalsTest.testObjectMapperOverride.approved.json
@@ -1,0 +1,3 @@
+{
+  "lastName" : "MyClass"
+}

--- a/approvaltests/pom.xml
+++ b/approvaltests/pom.xml
@@ -37,6 +37,18 @@
         <url>https://github.com/approvals/ApprovalTests.Java</url>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>3.0.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.approvaltests</groupId>
@@ -78,6 +90,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.20.1</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/approvaltests/src/main/java/org/approvaltests/JsonJackson3Approvals.java
+++ b/approvaltests/src/main/java/org/approvaltests/JsonJackson3Approvals.java
@@ -1,0 +1,54 @@
+package org.approvaltests;
+
+import com.spun.util.ObjectUtils;
+import org.approvaltests.core.Options;
+import org.lambda.functions.Function1;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+public class JsonJackson3Approvals
+{
+  private JsonJackson3Approvals()
+  {
+  }
+
+  public static void verifyAsJson(Object o)
+  {
+    verifyAsJson(o, new Options());
+  }
+
+  public static void verifyAsJson(Object o, Options options)
+  {
+    verifyAsJson(o, a -> a, options);
+  }
+
+  public static void verifyAsJson(Object o, Function1<JsonMapper.Builder, JsonMapper.Builder> objectMapperBuilder)
+  {
+    verifyAsJson(o, objectMapperBuilder, new Options());
+  }
+
+  public static void verifyAsJson(Object o, Function1<JsonMapper.Builder, JsonMapper.Builder> objectMapperBuilder,
+      Options options)
+  {
+    Approvals.verify(asJson(o, objectMapperBuilder), options.forFile().withExtension(".json"));
+  }
+
+  public static String asJson(Object o)
+  {
+    return asJson(o, a -> a);
+  }
+
+  public static String asJson(Object o, Function1<JsonMapper.Builder, JsonMapper.Builder> objectMapperBuilder)
+  {
+    try
+    {
+      ObjectMapper objectMapper = objectMapperBuilder.call(JsonMapper.builder()).build();
+      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(o);
+    }
+    catch (JacksonException e)
+    {
+      throw ObjectUtils.throwAsError(e);
+    }
+  }
+}


### PR DESCRIPTION
## Description

The library currently supports using Jackson to verify JSON objects. A new version of Jackson (3.x) has been released with API changes. The current `JsonJacksonApprovals` class cannot be used. 

## The solution

I created a new class, `JsonJackson3Approvals`, which has the same API as the current `JsonJacksonApprovals` class, in order to provide support for this new version. The same tests are also provided.

## Summary by Sourcery

Add Jackson 3 JSON verification support alongside existing Jackson 2 integration.

New Features:
- Introduce JsonJackson3Approvals to support JSON verification using Jackson 3 with an API parallel to the existing Jackson 2 helper.

Enhancements:
- Add Jackson 3 ObjectMapper builder customization support when verifying JSON output.

Build:
- Add Jackson 3 BOM and jackson-databind dependencies to the main and test POMs to manage Jackson 3 versions.

Tests:
- Add JsonJackson3Approvals tests and approved JSON files to validate behavior and ensure compatibility with Jackson 3.