### PR TITLE
- B PackageSettings only needs to support private ctor if the members are all static

### DIFF
--- a/approvaltests-tests/src/test/java/org/packagesettings/subpackage/PackageSettings.java
+++ b/approvaltests-tests/src/test/java/org/packagesettings/subpackage/PackageSettings.java
@@ -5,7 +5,4 @@ public class PackageSettings
   public String   name        = "Test Name";
   private boolean rating      = true;
   public String   ratingScale = "logarithmic";
-  private PackageSettings()
-  {
-  }
 }

--- a/approvaltests-tests/src/test/java/org/packagesettings/subpackage_static/PackageSettings.java
+++ b/approvaltests-tests/src/test/java/org/packagesettings/subpackage_static/PackageSettings.java
@@ -1,0 +1,11 @@
+package org.packagesettings.subpackage_static;
+
+final class PackageSettings
+{
+  static String  name        = "Test Name";
+  static boolean rating      = true;
+  static String  ratingScale = "logarithmic";
+  private PackageSettings()
+  {
+  }
+}

--- a/approvaltests-tests/src/test/java/org/packagesettings/subpackage_static/PackageSettingsTest.java
+++ b/approvaltests-tests/src/test/java/org/packagesettings/subpackage_static/PackageSettingsTest.java
@@ -1,0 +1,16 @@
+package org.packagesettings.subpackage_static;
+
+import org.approvaltests.Approvals;
+import org.junit.jupiter.api.Test;
+import org.packagesettings.PackageLevelSettings;
+
+public class PackageSettingsTest
+{
+  // https://docs.openrewrite.org/recipes/staticanalysis/hideutilityclassconstructor says:
+  //     Ensures utility classes (classes containing only static methods or fields in their API) do not have a public constructor.
+  @Test
+  public void testRetrieveValueWithPrivateConstructor()
+  {
+    Approvals.verify(PackageLevelSettings.get());
+  }
+}

--- a/approvaltests-tests/src/test/java/org/packagesettings/subpackage_static/PackageSettingsTest.testRetrieveValueWithPrivateConstructor.approved.txt
+++ b/approvaltests-tests/src/test/java/org/packagesettings/subpackage_static/PackageSettingsTest.testRetrieveValueWithPrivateConstructor.approved.txt
@@ -1,0 +1,4 @@
+lastName : Falco [from org.packagesettings.PackageSettings] 
+name : Test Name [from org.packagesettings.subpackage_static.PackageSettings] 
+rating : true [from org.packagesettings.subpackage_static.PackageSettings] 
+ratingScale : logarithmic [from org.packagesettings.subpackage_static.PackageSettings] 

--- a/approvaltests-util/src/main/java/org/packagesettings/PackageLevelSettings.java
+++ b/approvaltests-util/src/main/java/org/packagesettings/PackageLevelSettings.java
@@ -50,7 +50,7 @@ public class PackageLevelSettings
     {
       Class<?> clazz = loadClass(packageName + "." + PACKAGE_SETTINGS);
       Field[] declaredFields = clazz.getDeclaredFields();
-      Object o = createInstance(clazz);
+      Object o = null;
       for (Field field : declaredFields)
       {
         if (Modifier.isStatic(field.getModifiers()))
@@ -59,6 +59,10 @@ public class PackageLevelSettings
         }
         else
         {
+          if (o == null)
+          {
+            o = createInstance(clazz);
+          }
           settings.put(field.getName(), getFieldValue(field, o));
         }
       }


### PR DESCRIPTION
No need to override accessibility of the ctor.

Fixes #370

## Summary by Sourcery

Support package-level settings classes that only expose static members and may have private constructors, by lazily instantiating settings classes only when non-static fields are accessed.

New Features:
- Allow PackageSettings classes with only static members and private constructors to be used with PackageLevelSettings.

Bug Fixes:
- Prevent failures when resolving package-level settings for classes whose constructors are not publicly accessible but only static members are needed.

Tests:
- Add tests covering static-only PackageSettings classes with private constructors and adjust existing package settings test fixtures accordingly.