### PR TITLE
- F better help message for DateScrubber

### DIFF
--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTest.java
@@ -252,4 +252,11 @@ public class DateScrubberTest
     String result = "created at " + sdf.format(new Date());
     Approvals.verify(result, new Options().inline(expected).withScrubber(scrubber));
   }
+
+  @Test
+  @UseReporter(AutoApproveReporter.class)
+  void testDateFormatNotFoundMessage()
+  {
+      Approvals.verifyException(() -> DateScrubber.getScrubberFor("this format does not exist"));
+  }
 }

--- a/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTest.testDateFormatNotFoundMessage.approved.txt
+++ b/approvaltests-tests/src/test/java/org/approvaltests/scrubbers/DateScrubberTest.testDateFormatNotFoundMessage.approved.txt
@@ -1,0 +1,23 @@
+com.spun.util.FormattedException: No match found for this format does not exist.
+Feel free to add your date at https://github.com/approvals/ApprovalTests.Java/issues/112 
+Current supported formats are: 
+	[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{2}:\d{2}:\d{2}
+	[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{2}:\d{2}:\d{2} [a-zA-Z]{3,4} \d{4}
+	(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT
+	[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{4} \d{2}:\d{2}:\d{2}.\d{3}
+	[a-zA-Z]{3} [a-zA-Z]{3} \d{2} \d{2}:\d{2}:\d{2} -\d{4} \d{4}
+	\d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2},\d{3}
+	[A-Za-z]{3} \d{2} \d{2}:\d{2}
+	[a-zA-Z]{3} \d{2}, \d{4} \d{2}:\d{2}:\d{2} [a-zA-Z]{2} [a-zA-Z]{3}
+	\d{2}:\d{2}:\d{2}
+	\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}(\.\d{3})?
+	\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}Z
+	\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}:\d{2}Z
+	\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}\:\d{2}\.\d{3}Z
+	\d{8}T\d{6}Z
+	\d{4}-\d{2}-\d{2}
+	\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}:\d{2}(\.\d{1,9})?Z
+	\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}:\d{2}(\.\d{1,9})?[+-]\d{2}:\d{2}
+	\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{2}:\d{2}(\.\d{1,9})?
+	\d{2}[-/.]\d{2}[-/.]\d{4}\s\d{2}:\d{2}(:\d{2})?( (?:pm|am|PM|AM))?
+	\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+

--- a/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
+++ b/approvaltests/src/main/java/org/approvaltests/scrubbers/DateScrubber.java
@@ -93,8 +93,8 @@ public class DateScrubber extends RegExScrubber
       { return scrubber; }
     }
     throw new FormattedException(
-        "No match found for %s.\n Feel free to add your date at https://github.com/approvals/ApprovalTests.Java/issues/112 \n Current supported formats are: %s",
-        formattedExample, Query.select(getSupportedFormats(), SupportedFormat::getRegex));
+        "No match found for %s.\nFeel free to add your date at https://github.com/approvals/ApprovalTests.Java/issues/112 \nCurrent supported formats are: \n\t%s",
+        formattedExample, Query.select(getSupportedFormats(), SupportedFormat::getRegex).join("\n\t"));
   }
 
   public static DateScrubber getNull()


### PR DESCRIPTION
## This should be small

Small pull requests are great and easy for me to understand and accept
Please try prefix every commits in the pull request with  [Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md)
| Prefix | Meaning |
|--------|---------|
| e   | development enviroment only - not production|
| d   | documentation only|
| t   | tests only|
| R!! | Refactoring |
| B!! | Bug Fix |
| F!! | New Feature |

## But it's not small!

Then you should setup a remote pairing session with Llewellyn ( llewellyn.falco@gmail.com )
Usually the sessions are between 45-90 minutes.

assuming you still feel it is small, please include

## Description

A description of what the PR achieves.

## The solution

Outline the implementation.
Any tests that are affected.

## Notation

I prefer lots of very small commits prefixed with [Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md)

## Summary by Sourcery

Improve DateScrubber’s error message when a date format is not found and add test coverage for the new message.

Enhancements:
- Refine DateScrubber’s no-match error message to clearly list supported date format patterns on separate lines.

Tests:
- Add a regression test and approved output file to verify the DateScrubber no-match error message.