### PR TITLE
Add support for serializing null Instant values in JSON

### DIFF
--- a/approvaltests-tests/src/test/java/org/approvaltests/JsonApprovalsTest.java
+++ b/approvaltests-tests/src/test/java/org/approvaltests/JsonApprovalsTest.java
@@ -3,6 +3,7 @@ package org.approvaltests;
 import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 public class JsonApprovalsTest
@@ -37,6 +38,26 @@ public class JsonApprovalsTest
       this.localDate = localDate;
     }
     private LocalDateTime localDate;
+  }
+
+  @Test
+  void nullInstantTest()
+  {
+      InstantWrapper instantWrapper = new InstantWrapper();
+      JsonApprovals.verifyAsJson(instantWrapper, g -> g.serializeNulls());
+  }
+  private class InstantWrapper
+  {
+    public Instant getInstant()
+    {
+      return instant;
+    }
+
+    public void setInstant(Instant instant)
+    {
+      this.instant = instant;
+    }
+    private Instant instant;
   }
   @Test
   void verifyJsonReorderWithoutArray()

--- a/approvaltests-tests/src/test/java/org/approvaltests/JsonApprovalsTest.nullInstantTest.approved.json
+++ b/approvaltests-tests/src/test/java/org/approvaltests/JsonApprovalsTest.nullInstantTest.approved.json
@@ -1,0 +1,3 @@
+{
+  "instant": null
+}

--- a/approvaltests-util/src/main/java/com/spun/util/JsonUtils.java
+++ b/approvaltests-util/src/main/java/com/spun/util/JsonUtils.java
@@ -147,7 +147,14 @@ public class JsonUtils
     @Override
     public void write(JsonWriter jsonWriter, Instant instant) throws IOException
     {
-      jsonWriter.value(instant.toString());
+      if (instant == null)
+      {
+        jsonWriter.nullValue();
+      }
+      else
+      {
+        jsonWriter.value("" + instant);
+      }
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes NullPointerException when serializing null Instant values
Issue: https://github.com/approvals/ApprovalTests.Java/issues/765

## The solution

null check before calling instant.toString()

## Summary by Sourcery

Handle null Instant values during JSON serialization and cover the behavior with a regression test.

Bug Fixes:
- Prevent NullPointerException when serializing null Instant values to JSON.

Tests:
- Add a regression test and approved JSON file to verify serialization of null Instant values.