### PR TITLE
. e Add Java 26 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
             - '21'
             - '24'
             - '25'
+            - '26'
         os: 
             - ubuntu
             - windows


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add Java 26 to the GitHub Actions test matrix for ubuntu and windows runners.